### PR TITLE
CDF Loadouts update

### DIFF
--- a/CO18_CZ_Altis_V29.Altis/tb3/murk/cdf_blk.hpp
+++ b/CO18_CZ_Altis_V29.Altis/tb3/murk/cdf_blk.hpp
@@ -8,7 +8,7 @@
         {"arifle_msbs65_black_f",
           {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"}
         },
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
@@ -61,7 +61,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_erco_blk_f",},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -95,7 +95,7 @@
       {"arifle_msbs65_ubs_black_f",
         {"30rnd_65x39_caseless_msbs_mag","6rnd_12gauge_pellets","ace_acc_pointer_green", "optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -131,7 +131,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -152,10 +152,10 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
-      {"30rnd_65x39_caseless_msbs_mag",6},
+      {"30rnd_65x39_caseless_msbs_mag",4},
       {"SmokeShell",2},
-      {"SmokeshellRed", 2},
-      {"SmokeShellGreen", 2},
+      {"SmokeshellRed", 1},
+      {"SmokeShellGreen", 1},
       {"ace_microdagr",1},
       {"ITC_Land_B_AR2i_Packed",2},
       {"ACE_UAVBattery",2}
@@ -169,7 +169,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_Holosight_blk_F",},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
@@ -201,7 +201,7 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"crab_radiobag_01_black_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
@@ -212,21 +212,20 @@
     };
   };
 
-  class DM: baseUnit {
+  class HRF: baseUnit {
 
     weapons[] = {
-      {"srifle_dmr_03_f",
-        {"ace_20rnd_762x51_mk319_mod_0_mag","ace_acc_pointer_green","rhsusf_acc_su230a","rhs_acc_harris_swivel"}
+      {"CUP_arifle_Mk17_CQC_SFG_black",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_tws_mg"}
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
     };
 
-    vest[] = {"V_platecarrier2_blk"};
+    vest[] = {"V_platecarrier1_blk"};
     vestContents[] = {
-      {"ace_20rnd_762x51_mk319_mod_0_mag",6},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -235,9 +234,43 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_b",1},
-      {"ace_20rnd_762x51_mk319_mod_0_mag",4},
-      {"ace_20rnd_762x51_mag_tracer",2},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_arifle_mk20_black",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_ams","bipod_02_f_blk"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_vector"
+    };
+
+    vest[] = {"V_platecarrier1_blk"};
+    vestContents[] = {
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -251,7 +284,7 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
@@ -279,13 +312,44 @@
     };
   };
 
+  class SMG: baseUnit {
+
+    weapons[] = {
+      {"rhsusf_weap_mp7a2",
+        {"rhsusf_mag_40rnd_46x30_jhp","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      }
+    };
+
+    vest[] = {"V_platecarrier1_blk"};
+    vestContents[] = {
+      {"rhsusf_mag_40rnd_46x30_jhp",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_viperlightharness_blk_f"};
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"rhsusf_mag_40rnd_46x30_jhp",6},
+      {"ace_cts9",2},
+      {"ace_m84",2},
+      {"16rnd_9x21_mag",4},
+      {"handgrenade",4}
+    };
+  };
+
   class GN: baseUnit {
 
     weapons[] = {
       {"arifle_msbs65_gl_black_f",
         {"30rnd_65x39_caseless_msbs_mag", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F", "rhsusf_acc_grip1"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       }
     };
@@ -317,13 +381,15 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
+    vest[] = {"V_tacvestir_blk"};
+
     backpack[]={"b_viperlightharness_blk_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
@@ -340,7 +406,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -362,13 +428,15 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
+    vest[] = {"V_tacvestir_blk"};
+
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f",1},
@@ -383,7 +451,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -406,7 +474,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
-      {"30rnd_65x39_caseless_msbs_mag",6},
+      {"30rnd_65x39_caseless_msbs_mag",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -441,25 +509,25 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_mk48_nohg",
+        {"150rnd_762x51_box","rhsusf_acc_anpeq15side_bk","Optic_ERCO_blk_f"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vest[] = {"V_tacvestir_blk"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
-      {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
+      {"150rnd_762x51_box",2},
+      {"16rnd_9x21_mag",1},
       {"ace_maptools",1}
     };
 
     backpack[]={"b_viperlightharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_black_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"150rnd_762x51_box",4},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
@@ -472,7 +540,7 @@
       {"lmg_mk200_black_f",
         {"200rnd_65x39_cased_box","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_harris_swivel"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
@@ -480,11 +548,11 @@
     vestContents[] = {
       {"200rnd_65x39_cased_box",2},
       {"16rnd_9x21_mag",2},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
       {"200rnd_65x39_cased_box",4},
       {"SmokeShell",2},
@@ -498,7 +566,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
@@ -506,13 +574,14 @@
 
     backpack[]={"b_viperharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f",1},
       {"30rnd_65x39_caseless_msbs_mag",4},
       {"30rnd_65x39_caseless_msbs_mag_tracer",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
-      {"rhsusf_100Rnd_762x51_m62_tracer",2}
+      {"150rnd_762x51_box",2},	  
+      {"150rnd_762x51_box_tracer",2}
     };
   };
 
@@ -522,7 +591,7 @@
       {"smg_03c_tr_black",
         {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
@@ -543,6 +612,7 @@
 
     backpack[] = {"b_viperharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
       {"50rnd_570x28_smg_03",4},
       {"16rnd_9x21_mag",2},	  
@@ -581,8 +651,8 @@
       {"200rnd_65x39_cased_box",10},
       {"ace_20rnd_762x51_mk319_mod_0_mag",10},
       {"ace_20rnd_762x51_mag_tracer",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
-      {"rhsusf_100Rnd_762x51_m62_tracer",4},
+      {"150rnd_762x51_box",8},
+      {"150rnd_762x51_box_tracer",4},
       {"handgrenade",20},
       {"SmokeShell",10},
       {"rhs_mag_m433_hedp",20},

--- a/CO18_CZ_Altis_V29.Altis/tb3/murk/cdf_jng.hpp
+++ b/CO18_CZ_Altis_V29.Altis/tb3/murk/cdf_jng.hpp
@@ -1,4 +1,4 @@
-  class CDF_des {
+  class CDF_jng {
     class BaseUnit {
       ace_earplugs = 1;
       allowPlayerGoggles = 0;
@@ -6,11 +6,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -20,14 +20,31 @@
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhs_booniehat2_marpatd"};
-
-      goggles[] = {
-        "rhsusf_shemagh_gogg_tan",		
-        "rhsusf_shemagh2_gogg_tan"
+      headgear[] = {
+        "h_bandanna_khk_hs",
+		"rhsusf_bowman_cap",
+		"h_cap_headphones",
+		"h_cap_oli_hs",
+        "H_Booniehat_tna_F",
+        "H_MilCap_tna_F"
       };
 
-      uniform[] = {"rhs_uniform_emr_des_patchless"};
+      goggles[] = {
+		"g_bandanna_oli",
+		"rhs_googles_clear",
+        "rhsusf_shemagh_grn",
+        "rhsusf_shemagh2_grn",
+        "rhsusf_shemagh_od",
+        "rhsusf_shemagh2_od",
+        "rhsusf_shemagh_tan",		
+        "rhsusf_shemagh2_tan"
+      };
+
+      uniform[] = {
+        "U_B_T_Soldier_F",
+        "U_B_T_Soldier_AR_F",
+        "U_B_T_Soldier_SL_F"
+      };
       uniformContents[] = {
         {"ACE_fieldDressing",4},
         {"ACE_elasticBandage",4},
@@ -40,20 +57,20 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {v_tacchestrig_grn_f};
+      vest[] = {V_SmershVest_01_F};
       vestContents[] = {
-        {"CUP_20Rnd_762x51_B_SCAR",6},
+        {"rhsgref_30rnd_556x45_vhs2",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
         {"ace_maptools",1}
       };
 
-      backpack[] = {"b_kitbag_rgr"};
+      backpack[] = {"b_carryall_green_f"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsgref_sdn6_silencer", 1},
-        {"CUP_20Rnd_762x51_B_SCAR",4},
+        {"muzzle_snds_m_khk_F", 1},
+        {"rhsgref_30rnd_556x45_vhs2",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,11 +80,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -75,9 +92,9 @@
       },
       "ace_vector"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +104,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,11 +119,11 @@
   class TL: SL {
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -114,9 +131,9 @@
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +142,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,11 +158,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -153,10 +170,10 @@
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -165,11 +182,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -185,11 +202,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -197,10 +214,10 @@
       },
       "Laserdesignator_03"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -209,12 +226,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -224,12 +241,12 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"crab_radiobag_01_wdl_f"};
+    backpack[]={"crab_radiobag_01_tropic_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -238,8 +255,8 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"cup_arifle_mk20",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
+      {"srifle_DMR_03_khaki_F",
+        {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag","ace_acc_pointer_green","optic_ams_khk","rhs_acc_harris_swivel"}
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -247,9 +264,9 @@
       "ace_vector"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -259,9 +276,9 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"optic_tws_mg",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_B",1},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",4},
+	  {"ACE_20Rnd_762x51_Mag_Tracer",4},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -281,7 +298,7 @@
       "ace_yardage450"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"rhsusf_mag_6rnd_m433_hedp",2},
       {"rhsusf_mag_6rnd_m441_he",1},
@@ -307,11 +324,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_cqc_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_G36A_AG36_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","rhsgref_30rnd_556x45_vhs2","CUP_1Rnd_HE_M203"}
         },
-        {"CUP_arifle_Mk17_STD_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_G36K_RIS_AG36_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","rhsgref_30rnd_556x45_vhs2","CUP_1Rnd_HE_M203"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -319,23 +336,24 @@
         }
       };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"cup_1rnd_hedp_m203",12},
-      {"cup_1rnd_he_m203",12},
-      {"rhs_mag_m714_white", 4}
+      {"CUP_1Rnd_HE_M203",12},
+      {"CUP_1Rnd_HEDP_M203",12},
+      {"1_rnd_smoke_grenade_shell", 4}
     };
   };
   class UGL: GN {};
@@ -343,8 +361,8 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -353,11 +371,11 @@
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
-    backpack[]={"b_kitbag_rgr"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -367,11 +385,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -380,11 +398,11 @@
         "ace_vector"
       };
     
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -393,8 +411,8 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -403,10 +421,11 @@
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"Titan_AT", 1}
     };
   };
@@ -415,11 +434,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -428,11 +447,11 @@
       "ace_mx2a"
     };
     
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -444,8 +463,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -466,13 +485,15 @@
   class MED: ME {};
 
   class RM: baseUnit {
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 4},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"150rnd_762x51_box",1},
+	  {"CUP_100Rnd_556x45_BetaCMag",1},	  
+      {"150rnd_762x51_box",1},      
       {"ACE_salineIV_500",1}
     };
   };
@@ -480,8 +501,8 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"cup_lmg_mk48_nohg_tan",
-        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
+      {"CUP_lmg_mk48_nohg_od",
+        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_khk_f"},
       },
       {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
@@ -495,24 +516,48 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_kitbag_rgr"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_h_mg_blk_f",1},
-      {"150rnd_762x51_box",4},
+      {"muzzle_snds_m_khk_F",1},
+      {"150rnd_762x51_box",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class LMG: GPMG {};
+  class MG: GPMG {};
 
-  class MG: GPMG {}; 
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_MG36_wdl",
+        {"CUP_100Rnd_556x45_BetaCMag","ace_acc_pointer_green","optic_Holosight_khk_F"},
+      },
+      {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"CUP_100Rnd_556x45_BetaCMag",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"muzzle_snds_m_khk_F",1},
+      {"CUP_100Rnd_556x45_BetaCMag",4},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
+      {"CUP_arifle_MG36_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","Optic_ERCO_khk_f"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -520,12 +565,12 @@
       "binocular"
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",2},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2",4},
+      {"rhsgref_30rnd_556x45_vhs2_t",2},
       {"SmokeShell",2},
       {"handgrenade",2},
       {"150rnd_762x51_box",2},	  
@@ -536,10 +581,10 @@
   class PT: baseUnit {
 
     weapons[] = {
-      {"cup_smg_mac10_rail",
-        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"}
       },
-      {"CUP_hgun_Duty",
+      {"CUP_hgun_duty",
         {"16rnd_9x21_mag"}
       }
     };
@@ -555,7 +600,7 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhsgref_30rnd_556x45_vhs2",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
@@ -564,7 +609,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhsgref_30rnd_556x45_vhs2",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -589,7 +634,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_carryall_green_f",2}
+      {"B_Bergen_tna_F",2}
     };
   };
   class LargeGearCrate {
@@ -598,12 +643,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",60},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
-      {"150rnd_762x51_box",20},
+      {"rhsgref_30rnd_556x45_vhs2",40},
+      {"rhsgref_30rnd_556x45_vhs2_t",10},
+      {"CUP_100Rnd_556x45_BetaCMag",20},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",10},
+      {"150rnd_762x51_box",8},
+      {"150rnd_762x51_box_tracer",2},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"cup_1rnd_hedp_m203",20},
+      {"CUP_1Rnd_HE_M203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -626,7 +674,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_carryall_green_f",4}
+      {"B_Bergen_tna_F",4}
     };
   };
 };

--- a/CO18_CZ_Altis_V29.Altis/tb3/murk/cdf_liz.hpp
+++ b/CO18_CZ_Altis_V29.Altis/tb3/murk/cdf_liz.hpp
@@ -1,0 +1,680 @@
+  class CDF_liz {
+    class BaseUnit {
+      ace_earplugs = 1;
+      allowPlayerGoggles = 0;
+      ace_medic = 1;
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        }
+      };
+
+      assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
+
+      headgear[] = {
+        "h_bandanna_khk_hs",
+		"rhsusf_bowman_cap",
+		"h_cap_headphones",
+		"h_cap_oli_hs",
+        "H_Booniehat_khk",
+        "H_MilCap_grn"
+      };
+
+      goggles[] = {
+		"g_bandanna_oli",
+		"rhs_googles_clear",
+        "rhsusf_shemagh_grn",
+        "rhsusf_shemagh2_grn",
+        "rhsusf_shemagh_od",
+        "rhsusf_shemagh2_od",
+        "rhsusf_shemagh_tan",		
+        "rhsusf_shemagh2_tan"
+      };
+
+      uniform[] = {
+        "rhsgref_uniform_altis_lizard",
+        "rhsgref_uniform_altis_lizard_olive"
+      };
+      uniformContents[] = {
+        {"ACE_fieldDressing",4},
+        {"ACE_elasticBandage",4},
+        {"ACE_quikclot",4},
+        {"ACE_morphine",2},
+        {"ACE_adenosine",1},
+        {"ACE_tourniquet",2},
+        {"ACE_Splint",2},
+        {"ACE_salineIV_500",1},
+        {"ACE_Flashlight_XL50",1}
+      };
+
+      vest[] = {V_HarnessO_ghex_F};
+      vestContents[] = {
+        {"rhs_30Rnd_762x39mm_89",6},
+        {"handgrenade",2},
+        {"SmokeShell",2},
+        {"16rnd_9x21_mag",2},
+        {"ace_maptools",1}
+      };
+
+      backpack[] = {"b_viperlightharness_ghex_f"};
+      backpackContents[] = {
+        {"CUP_nvg_pvs7",1},
+        {"rhs_acc_pbs1", 1},
+        {"rhs_30Rnd_762x39mm_89",4},
+        {"SmokeShell",2},
+        {"handgrenade",2}
+      };
+    };
+
+  class SL: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_acc_pso1m21"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_acc_pso1m21"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"acre_prc148",1},
+      {"16rnd_9x21_mag",2},
+      {"itc_land_tablet_rover",1},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"ace_ir_strobe_item",1},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 4},
+      {"SmokeShellGreen", 4},
+      {"ace_microdagr",1}
+    };
+  };
+  class PL: SL {};
+  class ZEUS: SL {};
+  class TL: SL {
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"acre_prc148",1},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"ace_ir_strobe_item",1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 4},
+      {"SmokeShellGreen", 4},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class DFO: SL {
+    assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio","B_UavTerminal"};
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "binocular"
+      };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"acre_prc148",2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"ace_microdagr",1},
+      {"ITC_Land_B_AR2i_Packed",2},
+      {"ACE_UAVBattery",2}
+    };
+  };
+
+  class FSO: DFO {};
+  class FO: DFO {
+    assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "Laserdesignator_03"
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"acre_prc148",1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"laserbatteries",2},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class RTO: baseUnit {
+    backpack[]={"crab_radiobag_01_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"ACRE_PRC117F",1}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_srifle_svd",
+        {"rhs_10Rnd_762x54mmR_7N14","rhs_acc_pso1m2","cup_svd_camo_g"}
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_10Rnd_762x54mmR_7N14",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"CUP_muzzle_snds_KZRZP_SVD",1},
+      {"rhs_10Rnd_762x54mmR_7N14",6},
+	  {"ACE_10Rnd_762x54_Tracer_mag",4},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+  class DMR: DM {};
+
+  class MGL: baseUnit {
+
+    weapons[] = {
+      {"CUP_glaunch_6G30",
+        {"CUP_6Rnd_HE_GP25_M"}
+      },
+        {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"CUP_6Rnd_HE_GP25_M",2},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"CUP_6Rnd_HE_GP25_M",4},
+      {"16rnd_9x21_mag",4},
+      {"handgrenade",2},
+      {"SmokeShell",2}
+    };
+  };
+
+  class GN: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM_gl",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_vog25"}
+        },
+        {"CUP_arifle_AKMS_gl",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_vog25"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        }
+      };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",8},
+      {"handgrenade", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"handgrenade",2},
+      {"rhs_vog25",12},
+      {"rhs_vog25p",8},
+	  {"rhs_vg40tb",4},
+      {"1_rnd_smoke_grenade_shell", 4}
+    };
+  };
+  class UGL: GN {};
+
+  class MAT: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKMS",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      {"rhs_weap_rpg7",
+        {"rhs_rpg7_pg7v_mag"}
+      }
+    };
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7v_mag", 1},
+      {"rhs_rpg7_og7v_mag", 2}
+    };
+  };
+
+  class MATA: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7v_mag", 2},
+      {"rhs_rpg7_og7v_mag", 2}
+    };
+  };
+
+  class HAT: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKMS",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      {"rhs_weap_rpg7",
+        {"rhs_rpg7_og7v_mag"}
+      }
+    };
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7vr_mag", 2},
+      {"rhs_rpg7_og7v_mag", 1}
+    };
+  };
+
+  class HATA: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7vr_mag", 2},
+	  {"rhs_rpg7_og7v_mag",1},
+      {"rhs_rpg7_tbg7v_mag", 1}
+    };
+  };
+
+  class ME: baseUnit {
+    ace_medic = 2;
+    vest[] = {"V_HarnessO_ghex_F"};
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"ACE_fieldDressing",15},
+      {"ACE_packingBandage",10},
+      {"ACE_quikclot",15},
+      {"ACE_elasticBandage",15},
+      {"ACE_morphine",8},
+      {"ACE_epinephrine",8},
+      {"ACE_adenosine",8},
+      {"ACE_salineIV_250",4},
+      {"ACE_salineiv_500",4},
+      {"ACE_salineiv",2},
+      {"ACE_bloodIV",4},
+      {"ACE_personalAidKit",1},
+      {"ACE_surgicalKit",1},
+      {"ACE_splint",8},
+      {"ACE_tourniquet",5}
+    };
+  };
+  class MED: ME {};
+
+  class RM: baseUnit {
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"handgrenade",4},
+      {"SmokeShell",2},
+	  {"rhs_75Rnd_762x39mm_89",1},	  
+      {"150rnd_762x54_box",1},      
+      {"ACE_salineIV_500",1}
+    };
+  };
+  class RF: RM {};
+
+  class GPMG: baseUnit {
+    weapons[] = {
+      {"CUP_lmg_PKMN",
+        {"150rnd_762x54_box","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"150rnd_762x54_box",1},
+      {"16rnd_9x21_mag",3},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+	  {"CUP_muzzle_snds_KZRZP_PK",1},
+      {"150rnd_762x54_box",3},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+  class MG: GPMG {};
+
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_rpk74",
+        {"rhs_75Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"rhs_75Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_75Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
+
+  class GPMGA: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKM",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "binocular"
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89",4},
+      {"rhs_30Rnd_762x39mm_tracer",2},
+      {"SmokeShell",2},
+      {"handgrenade",2},
+      {"150rnd_762x54_box",2},	  
+      {"150rnd_762x54_box_tracer",2}
+    };
+  };
+
+  class PT: baseUnit {
+
+    weapons[] = {
+      {"CUP_smg_Bizon",
+        {"CUP_64Rnd_9x19_Bizon_M","ace_acc_pointer_green"}
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      }
+    };
+
+    headgear[] = {
+      "rhsusf_hgu56p_visor_white",
+      "rhsusf_hgu56p_black",
+      "rhsusf_hgu56p_visor_mask_pink"
+      };
+
+    goggles[] = {rhs_balaclava1_olive};
+
+    vest[] = {"v_tacChestrig_oli_f"};
+    vestContents[] = {
+      {"acre_prc148",1},
+      {"CUP_64Rnd_9x19_Bizon_M",3},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[] = {"b_fieldpack_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"SmokeShell",2},
+      {"CUP_64Rnd_9x19_Bizon_M",3},
+      {"16rnd_9x21_mag",2},	  
+      {"SmokeShellgreen",2},
+      {"handgrenade",2},
+      {"Chemlight_green",2},
+      {"ace_ir_strobe_item",1},
+      {"Toolkit",1},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class PILOT: PT {};
+
+  class LauncherCrate {
+    vehCargoWeapons[] = {
+      {"rhs_weap_rpg26",10},
+	  {"rhs_weap_rshg2",4},
+      {"rhs_weap_rpg7",2},
+      {"ACE_Vector",2}
+    };
+    vehCargoMagazines[] = {
+      {"rhs_rpg7_og7v_mag",6},
+      {"rhs_rpg7_pg7v_mag",6},
+	  {"rhs_rpg7_tbg7v_mag",6},
+      {"rhs_rpg7_pg7vr_mag",6}
+    };
+    vehCargoRucks[] = {
+      {"b_carryall_ghex_f",2}
+    };
+  };
+  class LargeGearCrate {
+    vehCargoWeapons[] = {
+      {"rhs_weap_rpg26",6},
+      {"ACE_Vector",2}
+    };
+    vehCargoMagazines[] = {
+      {"rhs_30Rnd_762x39mm_89",40},
+      {"rhs_30Rnd_762x39mm_tracer",10},
+      {"rhs_75Rnd_762x39mm_89",20},
+      {"rhs_10Rnd_762x54mmR_7N14",10},
+      {"150rnd_762x54_box",8},
+      {"150rnd_762x54_box_tracer",2},
+      {"handgrenade",20},
+      {"SmokeShell",10},
+      {"rhs_vog25",15},
+	  {"rhs_vog25p",15},
+	  {"rhs_vg40tb",10},
+      {"DemoCharge_Remote_Mag",8}
+    };
+    vehCargoItems[] = {
+      {"ToolKit",1},
+      {"ACE_M26_Clacker",4},
+      {"ACE_DefusalKit",2},
+      {"ACE_fieldDressing",20},
+      {"ACE_packingBandage",20},
+      {"ACE_quikclot",20},
+      {"ACE_Tourniquet",8},
+      {"ACE_splint",4},
+      {"ACE_morphine",4},
+      {"ACE_epinephrine",4},
+      {"ACE_adenosine",4},
+      {"ACE_salineIV",4},      
+      {"ACE_salineIV_500",4},
+      {"ACE_Flashlight_MX991",4},
+      {"ACE_MapTools",4}
+    };
+    vehCargoRucks[] = {
+      {"b_carryall_ghex_f",4}
+    };
+  };
+};

--- a/CO18_CZ_Altis_V29.Altis/tb3/murk/cdf_rus.hpp
+++ b/CO18_CZ_Altis_V29.Altis/tb3/murk/cdf_rus.hpp
@@ -1,4 +1,4 @@
-  class CDF_des {
+  class CDF_rus {
     class BaseUnit {
       ace_earplugs = 1;
       allowPlayerGoggles = 0;
@@ -6,28 +6,35 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         }
       };
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhs_booniehat2_marpatd"};
+      headgear[] = {
+        "H_HelmetAggressor_cover_F",
+        "H_HelmetAggressor_F"
+      };
 
       goggles[] = {
+        "rhsusf_shemagh_gogg_grn",
+        "rhsusf_shemagh2_gogg_grn",
+        "rhsusf_shemagh_gogg_od",
+        "rhsusf_shemagh2_gogg_od",
         "rhsusf_shemagh_gogg_tan",		
         "rhsusf_shemagh2_gogg_tan"
       };
 
-      uniform[] = {"rhs_uniform_emr_des_patchless"};
+      uniform[] = {"U_O_R_Gorka_01_F"};
       uniformContents[] = {
         {"ACE_fieldDressing",4},
         {"ACE_elasticBandage",4},
@@ -40,9 +47,9 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {v_tacchestrig_grn_f};
+      vest[] = {V_CarrierRigKBT_01_light_Olive_F};
       vestContents[] = {
-        {"CUP_20Rnd_762x51_B_SCAR",6},
+        {"rhs_30Rnd_545x39_7N22_AK",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
@@ -52,8 +59,8 @@
       backpack[] = {"b_kitbag_rgr"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsgref_sdn6_silencer", 1},
-        {"CUP_20Rnd_762x51_B_SCAR",4},
+        {"rhs_acc_dtk4short", 1},
+        {"rhs_30Rnd_545x39_7N22_AK",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,21 +70,21 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","rhsusf_acc_su230","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","rhsusf_acc_su230","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +94,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,21 +109,21 @@
   class TL: SL {
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +132,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,22 +148,22 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -168,8 +175,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -185,22 +192,22 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -212,9 +219,9 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -227,9 +234,9 @@
     backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -238,18 +245,18 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"cup_arifle_mk20",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
+      {"srifle_DMR_05_blk_F",
+        {"10Rnd_93x64_DMR_05_Mag","ace_acc_pointer_green","optic_ams","rhs_acc_harris_swivel"}
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"10Rnd_93x64_DMR_05_Mag",5},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -259,9 +266,8 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"optic_tws_mg",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_93mmg",1},
+      {"10Rnd_93x64_DMR_05_Mag",5},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -272,19 +278,18 @@
   class MGL: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m32",
-        {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
+      {"CUP_glaunch_6G30",
+        {"CUP_6Rnd_HE_GP25_M"}
       },
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"rhsusf_mag_6rnd_m433_hedp",2},
-      {"rhsusf_mag_6rnd_m441_he",1},
+      {"CUP_6Rnd_HE_GP25_M",2},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -294,9 +299,7 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_mag_6rnd_m433_hedp",2},
-      {"rhsusf_mag_6rnd_m441_he",1},
-      {"rhsusf_mag_6rnd_m714_white",2},
+      {"CUP_6Rnd_HE_GP25_M",4},
       {"16rnd_9x21_mag",4},
       {"handgrenade",2},
       {"SmokeShell",2}
@@ -307,21 +310,21 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_cqc_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_AK107_GL_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_vog25","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_AK74M_GL_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_vog25","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         }
       };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -329,13 +332,14 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"cup_1rnd_hedp_m203",12},
-      {"cup_1rnd_he_m203",12},
-      {"rhs_mag_m714_white", 4}
+      {"rhs_vog25",12},
+      {"rhs_vog25p",8},
+      {"rhs_vg25tb",4},
+      {"rhs_vg40md", 4}
     };
   };
   class UGL: GN {};
@@ -343,23 +347,23 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_AK105_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
-      {"launch_MRAWS_green_rail_F",
-        {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
+      {"launch_RPG32_green_F",
+        {"RPG32_F", "ace_acc_pointer_green"}
       }
     };
     backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
-      {"MRAWS_HEAT55_F", 1},
-      {"MRAWS_HE_F", 2}
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
+      {"RPG32_F", 1},
+      {"RPG32_HE_F", 2}
     };
   };
 
@@ -367,14 +371,14 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
@@ -383,30 +387,30 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
-      {"MRAWS_HEAT55_F", 2},
-      {"MRAWS_HE_F", 2}
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
+      {"RPG32_F", 2},
+      {"RPG32_HE_F", 2}
     };
   };
 
   class HAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_AK105_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
-      {"launch_o_titan_short_f",
+      {"launch_I_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
       {"Titan_AT", 1}
     };
   };
@@ -415,14 +419,14 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_mx2a"
@@ -431,8 +435,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -440,12 +444,12 @@
 
   class ME: baseUnit {
     ace_medic = 2;
-    vest[] = {"V_SmershVest_01_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -468,11 +472,11 @@
   class RM: baseUnit {
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 4},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"150rnd_762x51_box",1},
+      {"150rnd_762x54_box",1},      
       {"ACE_salineIV_500",1}
     };
   };
@@ -480,17 +484,17 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"cup_lmg_mk48_nohg_tan",
-        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
+      {"CUP_lmg_Pecheneg",
+        {"150rnd_762x54_box","ace_acc_pointer_green","rhs_acc_ekp8_02d"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
       }
     };
-    vest[] = {"V_SmershVest_01_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"150rnd_762x51_box",1},
+      {"150rnd_762x54_box",1},
       {"16rnd_9x21_mag",3},
       {"ace_maptools",1}
     };
@@ -498,23 +502,47 @@
     backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_h_mg_blk_f",1},
-      {"150rnd_762x51_box",4},
+      {"CUP_muzzle_snds_KZRZP_PK",1},
+      {"150rnd_762x54_box",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class LMG: GPMG {};
+  class MG: GPMG {};
 
-  class MG: GPMG {}; 
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_RPK74M_railed",
+        {"CUP_60Rnd_545x39_AK74M_M","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"CUP_60Rnd_545x39_AK74M_M",4},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"rhs_acc_dtk4short",1},
+      {"CUP_60Rnd_545x39_AK74M_M",8},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
+      {"CUP_arifle_AK107_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "binocular"
@@ -523,23 +551,23 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",2},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK",4},
+      {"rhs_30Rnd_545x39_AK_green",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"150rnd_762x51_box",2},	  
-      {"150rnd_762x51_box_tracer",2}
+      {"150rnd_762x54_box",2},	  
+      {"150rnd_762x54_box_tracer",1}
     };
   };
 
   class PT: baseUnit {
 
     weapons[] = {
-      {"cup_smg_mac10_rail",
-        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      {"CUP_arifle_AKS74U_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"}
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       }
     };
@@ -555,7 +583,7 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhs_30Rnd_545x39_7N22_AK",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
@@ -564,7 +592,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhs_30Rnd_545x39_7N22_AK",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -598,12 +626,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",60},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
-      {"150rnd_762x51_box",20},
+      {"rhs_30Rnd_545x39_7N22_AK",40},
+      {"rhs_30Rnd_545x39_AK_green",10},
+      {"CUP_60Rnd_545x39_AK74M_M",20},
+      {"10Rnd_93x64_DMR_05_Mag",10},
+      {"150rnd_762x54_box",8},
+      {"150rnd_762x54_box_tracer",2},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"cup_1rnd_hedp_m203",20},
+      {"rhs_vog25",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}

--- a/CO18_CZ_Altis_V29.Altis/tb3/murk/cdf_wdl.hpp
+++ b/CO18_CZ_Altis_V29.Altis/tb3/murk/cdf_wdl.hpp
@@ -4,11 +4,16 @@
       allowPlayerGoggles = 0;
       ace_medic = 1;
 
-      weapons[] = {
-        {"rhs_weap_m16a4_imod_grip",
-          {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"}
+    weapons[] = {
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
         },
-        {"hgun_p07_khk_f",
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
@@ -47,7 +52,7 @@
 
       vest[] = {V_SmershVest_01_F};
       vestContents[] = {
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+        {"CUP_30Rnd_556x45_Emag",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
@@ -58,7 +63,7 @@
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
         {"rhsusf_acc_rotex5_grey", 1},
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+        {"CUP_30Rnd_556x45_Emag",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -67,17 +72,22 @@
   class SL: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "rhsusf_acc_su230","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -89,7 +99,7 @@
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -101,17 +111,22 @@
   class ZEUS: SL {};
   class TL: SL {
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -123,7 +138,7 @@
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -135,18 +150,23 @@
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio","B_UavTerminal"};
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -155,11 +175,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -168,15 +188,21 @@
       {"ACE_UAVBattery",2}
     };
   };
+
   class FSO: DFO {};
   class FO: DFO {
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
@@ -184,7 +210,7 @@
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -193,12 +219,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -208,32 +234,31 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
   };
 
-  class DM: baseUnit {
+  class HRF: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_sr25_ec",
-        {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a","rhsusf_acc_harris_bipod"}
+      {"CUP_arifle_Mk17_CQC_SFG_woodland",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_tws_mg"}
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
     };
 
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",6},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -242,9 +267,43 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
       {"rhsgref_sdn6_silencer",1},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",4},
-      {"rhsusf_20Rnd_762x51_sr25_M62_Mag",2},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_arifle_mk20_woodland",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_ams_khk","bipod_02_f_lush"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_vector"
+    };
+
+    vest[] = {"V_SmershVest_01_radio_F"};
+    vestContents[] = {
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -258,7 +317,7 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_khk_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
@@ -274,7 +333,7 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_mag_6rnd_m433_hedp",2},
@@ -289,17 +348,22 @@
   class GN: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_M203",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      }
-    };
+      {
+        {"CUP_arifle_Mk16_STD_EGLM_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag","cup_1rnd_hedp_m203"}
+        },
+        {"CUP_arifle_Mk16_CQC_EGLM_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag","cup_1rnd_hedp_m203"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        }
+      };
 
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",8},
+      {"CUP_30Rnd_556x45_Emag",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -308,11 +372,11 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhs_mag_m433_hedp",12},
-      {"rhs_mag_m441_he",12},
+      {"cup_1rnd_hedp_m203",12},
+      {"cup_1rnd_he_m203",12},
       {"rhs_mag_m714_white", 4}
     };
   };
@@ -321,10 +385,10 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
+      {"CUP_arifle_Mk16_CQC_FG_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
@@ -335,7 +399,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -344,20 +408,25 @@
   class MATA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -366,10 +435,10 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
+      {"CUP_arifle_Mk16_CQC_FG_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
@@ -379,7 +448,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"Titan_AT", 1}
     };
   };
@@ -387,20 +456,25 @@
   class HATA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
+      "ace_mx2a"
     };
     
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -409,11 +483,11 @@
   class ME: baseUnit {
     ace_medic = 2;
     vest[] = {"V_SmershVest_01_F"};
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -437,10 +511,10 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 6},
+      {"CUP_30Rnd_556x45_Emag", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote",1},
+      {"150Rnd_556x45_Drum_Green_Mag_f",1},
       {"ACE_salineIV_500",1}
     };
   };
@@ -448,25 +522,26 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_m60e4",
+        {"rhsusf_100Rnd_762x51_m61_ap","ace_acc_pointer_green","Optic_ERCO_blk_f"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"o_nvgoggles_grn_f",1},
+      {"rhsusf_100Rnd_762x51_m61_ap",3},
       {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
     backpack[]={"b_kitbag_sgg"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"rhsusf_100Rnd_762x51_m61_ap",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
@@ -476,15 +551,15 @@
   class LMG: baseUnit {
  
     weapons[] = {
-      {"rhs_weap_m249_light_S_vfg2",
-        {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote","rhsusf_acc_anpeq15side_bk","optic_Holosight_blk_F","rhsusf_acc_grip4_bipod"},
+      {"CUP_arifle_Mk16_SV_woodland",
+        {"150Rnd_556x45_Drum_Green_Mag_F","ace_acc_pointer_green","optic_Holosight_khk_F","bipod_02_F_lush"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vestContents[] = {
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",2},
+      {"150Rnd_556x45_Drum_Green_Mag_F",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
       {"handgrenade",2},
@@ -492,8 +567,9 @@
     };
 
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",4},
+      {"150Rnd_556x45_Drum_Green_Mag_F",6},
       {"SmokeShell",2},
       {"handgrenade",2}
     };   
@@ -502,23 +578,24 @@
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F"},
+      {"CUP_arifle_Mk16_SV_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F","bipod_02_F_lush"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
+      {"rhsusf_100Rnd_762x51_m61_ap",4},	  
       {"rhsusf_100Rnd_762x51_m62_tracer",2}
     };
   };
@@ -526,11 +603,11 @@
   class PT: baseUnit {
 
     weapons[] = {
-      {"smg_03c_tr_black",
-        {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
+      {"cup_smg_mac10_rail",
+        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
       },
-      {"hgun_p07_khk_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       }
     };
 
@@ -545,15 +622,16 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"50rnd_570x28_smg_03",2},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
-    backpack[] = {"b_tacticalpack_oli"};
+    backpack[] = {"b_fieldpack_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"50rnd_570x28_smg_03",4},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -563,7 +641,9 @@
       {"ace_microdagr",1}
     };
   };
+
   class PILOT: PT {};
+
   class LauncherCrate {
     vehCargoWeapons[] = {
       {"rhs_weap_m72a7",10},
@@ -576,7 +656,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_fieldpack_green_f",2}
+      {"b_carryall_green_f",2}
     };
   };
   class LargeGearCrate {
@@ -585,15 +665,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",40},
+      {"CUP_30Rnd_556x45_Emag",40},
       {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",10},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",10},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",10},
-      {"rhsusf_20Rnd_762x51_SR25_m62_Mag",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
+      {"150Rnd_556x45_Drum_Green_Mag_F",10},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",10},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",4},
+      {"rhsusf_100Rnd_762x51_m61_ap",8},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"rhs_mag_m433_hedp",20},
+      {"cup_1rnd_hedp_m203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -616,7 +696,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_carryall_oli",4}
+      {"b_carryall_green_f",4}
     };
   };
 };

--- a/CO18_CZ_Altis_V29.Altis/tb3/murk/loadouts.hpp
+++ b/CO18_CZ_Altis_V29.Altis/tb3/murk/loadouts.hpp
@@ -1,3 +1,6 @@
 #include "cdf_blk.hpp"
 #include "cdf_des.hpp"
 #include "cdf_wdl.hpp"
+#include "cdf_rus.hpp"
+#include "cdf_liz.hpp"
+#include "cdf_jng.hpp"

--- a/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_blk.hpp
+++ b/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_blk.hpp
@@ -8,7 +8,7 @@
         {"arifle_msbs65_black_f",
           {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"}
         },
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
@@ -61,7 +61,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_erco_blk_f",},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -95,7 +95,7 @@
       {"arifle_msbs65_ubs_black_f",
         {"30rnd_65x39_caseless_msbs_mag","6rnd_12gauge_pellets","ace_acc_pointer_green", "optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -131,7 +131,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -152,10 +152,10 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
-      {"30rnd_65x39_caseless_msbs_mag",6},
+      {"30rnd_65x39_caseless_msbs_mag",4},
       {"SmokeShell",2},
-      {"SmokeshellRed", 2},
-      {"SmokeShellGreen", 2},
+      {"SmokeshellRed", 1},
+      {"SmokeShellGreen", 1},
       {"ace_microdagr",1},
       {"ITC_Land_B_AR2i_Packed",2},
       {"ACE_UAVBattery",2}
@@ -169,7 +169,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_Holosight_blk_F",},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
@@ -201,7 +201,7 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"crab_radiobag_01_black_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
@@ -212,21 +212,20 @@
     };
   };
 
-  class DM: baseUnit {
+  class HRF: baseUnit {
 
     weapons[] = {
-      {"srifle_dmr_03_f",
-        {"ace_20rnd_762x51_mk319_mod_0_mag","ace_acc_pointer_green","rhsusf_acc_su230a","rhs_acc_harris_swivel"}
+      {"CUP_arifle_Mk17_CQC_SFG_black",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_tws_mg"}
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
     };
 
-    vest[] = {"V_platecarrier2_blk"};
+    vest[] = {"V_platecarrier1_blk"};
     vestContents[] = {
-      {"ace_20rnd_762x51_mk319_mod_0_mag",6},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -235,9 +234,43 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_b",1},
-      {"ace_20rnd_762x51_mk319_mod_0_mag",4},
-      {"ace_20rnd_762x51_mag_tracer",2},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_arifle_mk20_black",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_ams","bipod_02_f_blk"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_vector"
+    };
+
+    vest[] = {"V_platecarrier1_blk"};
+    vestContents[] = {
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -251,7 +284,7 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
@@ -279,13 +312,44 @@
     };
   };
 
+  class SMG: baseUnit {
+
+    weapons[] = {
+      {"rhsusf_weap_mp7a2",
+        {"rhsusf_mag_40rnd_46x30_jhp","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      }
+    };
+
+    vest[] = {"V_platecarrier1_blk"};
+    vestContents[] = {
+      {"rhsusf_mag_40rnd_46x30_jhp",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_viperlightharness_blk_f"};
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"rhsusf_mag_40rnd_46x30_jhp",6},
+      {"ace_cts9",2},
+      {"ace_m84",2},
+      {"16rnd_9x21_mag",4},
+      {"handgrenade",4}
+    };
+  };
+
   class GN: baseUnit {
 
     weapons[] = {
       {"arifle_msbs65_gl_black_f",
         {"30rnd_65x39_caseless_msbs_mag", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F", "rhsusf_acc_grip1"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       }
     };
@@ -317,13 +381,15 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
+    vest[] = {"V_tacvestir_blk"};
+
     backpack[]={"b_viperlightharness_blk_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
@@ -340,7 +406,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -362,13 +428,15 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
+    vest[] = {"V_tacvestir_blk"};
+
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f",1},
@@ -383,7 +451,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -406,7 +474,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
-      {"30rnd_65x39_caseless_msbs_mag",6},
+      {"30rnd_65x39_caseless_msbs_mag",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -441,25 +509,25 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_mk48_nohg",
+        {"150rnd_762x51_box","rhsusf_acc_anpeq15side_bk","Optic_ERCO_blk_f"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vest[] = {"V_tacvestir_blk"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
-      {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
+      {"150rnd_762x51_box",2},
+      {"16rnd_9x21_mag",1},
       {"ace_maptools",1}
     };
 
     backpack[]={"b_viperlightharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_black_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"150rnd_762x51_box",4},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
@@ -472,7 +540,7 @@
       {"lmg_mk200_black_f",
         {"200rnd_65x39_cased_box","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_harris_swivel"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
@@ -480,11 +548,11 @@
     vestContents[] = {
       {"200rnd_65x39_cased_box",2},
       {"16rnd_9x21_mag",2},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
       {"200rnd_65x39_cased_box",4},
       {"SmokeShell",2},
@@ -498,7 +566,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
@@ -506,13 +574,14 @@
 
     backpack[]={"b_viperharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f",1},
       {"30rnd_65x39_caseless_msbs_mag",4},
       {"30rnd_65x39_caseless_msbs_mag_tracer",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
-      {"rhsusf_100Rnd_762x51_m62_tracer",2}
+      {"150rnd_762x51_box",2},	  
+      {"150rnd_762x51_box_tracer",2}
     };
   };
 
@@ -522,7 +591,7 @@
       {"smg_03c_tr_black",
         {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
@@ -543,6 +612,7 @@
 
     backpack[] = {"b_viperharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
       {"50rnd_570x28_smg_03",4},
       {"16rnd_9x21_mag",2},	  
@@ -581,8 +651,8 @@
       {"200rnd_65x39_cased_box",10},
       {"ace_20rnd_762x51_mk319_mod_0_mag",10},
       {"ace_20rnd_762x51_mag_tracer",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
-      {"rhsusf_100Rnd_762x51_m62_tracer",4},
+      {"150rnd_762x51_box",8},
+      {"150rnd_762x51_box_tracer",4},
       {"handgrenade",20},
       {"SmokeShell",10},
       {"rhs_mag_m433_hedp",20},

--- a/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_des.hpp
+++ b/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_des.hpp
@@ -6,21 +6,21 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhsusf_protech_helmet_rhino"};
+      headgear[] = {"rhs_booniehat2_marpatd"};
 
       goggles[] = {
         "rhsusf_shemagh_gogg_tan",		
@@ -40,20 +40,20 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {V_platecarrier1_blk};
+      vest[] = {v_tacchestrig_grn_f};
       vestContents[] = {
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+        {"CUP_20Rnd_762x51_B_SCAR",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
         {"ace_maptools",1}
       };
 
-      backpack[] = {"b_viperlightharness_blk_f"};
+      backpack[] = {"b_kitbag_rgr"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsusf_acc_rotex5_grey", 1},
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+        {"rhsgref_sdn6_silencer", 1},
+        {"CUP_20Rnd_762x51_B_SCAR",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,21 +63,21 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +87,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,21 +102,21 @@
   class TL: SL {
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
-    vest[] = {"V_platecarrier1_blk"};
+        },
+        "ace_vector"
+      };
+    vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +125,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,22 +141,22 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
-    vest[] = {"V_platecarrier1_blk"};
+        },
+        "ace_vector"
+      };
+    vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -165,11 +165,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -178,28 +178,29 @@
       {"ACE_UAVBattery",2}
     };
   };
+
   class FSO: DFO {};
   class FO: DFO {
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
     weapons[] = {
       {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+        {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
     };
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -208,12 +209,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -223,12 +224,12 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -237,18 +238,18 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_sr25_ec_d",
-        {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a","rhsusf_acc_harris_bipod"}
+      {"cup_arifle_mk20",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -257,9 +258,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
       {"rhsgref_sdn6_silencer",1},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",4},
-      {"rhsusf_20Rnd_762x51_sr25_M62_Mag",2},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -273,13 +275,13 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
     };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
       {"rhsusf_mag_6rnd_m433_hedp",2},
       {"rhsusf_mag_6rnd_m441_he",1},
@@ -289,7 +291,7 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_mag_6rnd_m433_hedp",2},
@@ -304,17 +306,22 @@
   class GN: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m4a1_M203s_d",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F"},
-      },
-      {"hgun_p07_f",
-        {"16rnd_9x21_mag"}
-      }
-    };
+      {
+        {"CUP_arifle_Mk17_cqc_EGLM",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        },
+        {"CUP_arifle_Mk17_STD_EGLM",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        }
+      };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",8},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -322,12 +329,12 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhs_mag_m433_hedp",12},
-      {"rhs_mag_m441_he",12},
+      {"cup_1rnd_hedp_m203",12},
+      {"cup_1rnd_he_m203",12},
       {"rhs_mag_m714_white", 4}
     };
   };
@@ -336,26 +343,21 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        }
-      },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
-    backpack[]={"b_viperlightharness_blk_f"};
+    backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -365,24 +367,24 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+        },
+        "ace_vector"
+      };
     
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -391,16 +393,11 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        }
-      },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
@@ -408,8 +405,8 @@
     };
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"Titan_AT", 1}
     };
   };
@@ -418,24 +415,24 @@
 
     weapons[] = {
       {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+        {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
-      "ace_vector"
+      "ace_mx2a"
     };
     
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -443,12 +440,12 @@
 
   class ME: baseUnit {
     ace_medic = 2;
-    vest[] = {"V_tacvestir_blk"};
-    backpack[]={"b_viperharness_blk_f"};
+    vest[] = {"V_SmershVest_01_F"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -471,11 +468,11 @@
   class RM: baseUnit {
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 6},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 4},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote",1},
+      {"150rnd_762x51_box",1},
       {"ACE_salineIV_500",1}
     };
   };
@@ -483,89 +480,67 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_mk48_nohg_tan",
+        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
-    vest[] = {"V_tacvestir_blk"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"o_nvgoggles_grn_f",1},
+      {"150rnd_762x51_box",1},
       {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperlightharness_blk_f"};
+    backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"150rnd_762x51_box",4},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class MG: GPMG {};
+  class LMG: GPMG {};
 
-  class LMG: baseUnit {
- 
-    weapons[] = {
-      {"rhs_weap_m249_light_S_vfg2",
-        {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote","rhsusf_acc_anpeq15side_bk","optic_Holosight_blk_F","rhsusf_acc_grip4_bipod"},
-      },
-      {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
-      }
-    };
-    vestContents[] = {
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",2},
-      {"SmokeShell",2},
-      {"16rnd_9x21_mag",2},
-      {"handgrenade",2},
-      {"ace_maptools",1}
-    };
-
-    backpackContents[] = {
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",4},
-      {"SmokeShell",2},
-      {"handgrenade",2}
-    };   
-  };
+  class MG: GPMG {}; 
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F"},
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
-      {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",2},
+      {"o_nvgoggles_grn_f",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR",2},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
-      {"rhsusf_100Rnd_762x51_m62_tracer",2}
+      {"150rnd_762x51_box",2},	  
+      {"150rnd_762x51_box_tracer",2}
     };
   };
 
   class PT: baseUnit {
 
     weapons[] = {
-      {"smg_03c_tr_black",
-        {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
+      {"cup_smg_mac10_rail",
+        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
       },
-      {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       }
     };
 
@@ -580,15 +555,16 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"50rnd_570x28_smg_03",2},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
-    backpack[] = {"b_tacticalpack_oli"};
+    backpack[] = {"b_fieldpack_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"50rnd_570x28_smg_03",4},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -598,7 +574,9 @@
       {"ace_microdagr",1}
     };
   };
+
   class PILOT: PT {};
+
   class LauncherCrate {
     vehCargoWeapons[] = {
       {"rhs_weap_m72a7",10},
@@ -611,7 +589,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_fieldpack_green_f",2}
+      {"b_carryall_green_f",2}
     };
   };
   class LargeGearCrate {
@@ -620,15 +598,12 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",40},
-      {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",10},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",10},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",10},
-      {"rhsusf_20Rnd_762x51_SR25_m62_Mag",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
+      {"CUP_20Rnd_762x51_B_SCAR",60},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
+      {"150rnd_762x51_box",20},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"rhs_mag_m433_hedp",20},
+      {"cup_1rnd_hedp_m203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -651,7 +626,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_viperharness_blk_f",4}
+      {"b_carryall_green_f",4}
     };
   };
 };

--- a/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_jng.hpp
+++ b/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_jng.hpp
@@ -1,4 +1,4 @@
-  class CDF_des {
+  class CDF_jng {
     class BaseUnit {
       ace_earplugs = 1;
       allowPlayerGoggles = 0;
@@ -6,11 +6,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -20,14 +20,31 @@
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhs_booniehat2_marpatd"};
-
-      goggles[] = {
-        "rhsusf_shemagh_gogg_tan",		
-        "rhsusf_shemagh2_gogg_tan"
+      headgear[] = {
+        "h_bandanna_khk_hs",
+		"rhsusf_bowman_cap",
+		"h_cap_headphones",
+		"h_cap_oli_hs",
+        "H_Booniehat_tna_F",
+        "H_MilCap_tna_F"
       };
 
-      uniform[] = {"rhs_uniform_emr_des_patchless"};
+      goggles[] = {
+		"g_bandanna_oli",
+		"rhs_googles_clear",
+        "rhsusf_shemagh_grn",
+        "rhsusf_shemagh2_grn",
+        "rhsusf_shemagh_od",
+        "rhsusf_shemagh2_od",
+        "rhsusf_shemagh_tan",		
+        "rhsusf_shemagh2_tan"
+      };
+
+      uniform[] = {
+        "U_B_T_Soldier_F",
+        "U_B_T_Soldier_AR_F",
+        "U_B_T_Soldier_SL_F"
+      };
       uniformContents[] = {
         {"ACE_fieldDressing",4},
         {"ACE_elasticBandage",4},
@@ -40,20 +57,20 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {v_tacchestrig_grn_f};
+      vest[] = {V_SmershVest_01_F};
       vestContents[] = {
-        {"CUP_20Rnd_762x51_B_SCAR",6},
+        {"rhsgref_30rnd_556x45_vhs2",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
         {"ace_maptools",1}
       };
 
-      backpack[] = {"b_kitbag_rgr"};
+      backpack[] = {"b_carryall_green_f"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsgref_sdn6_silencer", 1},
-        {"CUP_20Rnd_762x51_B_SCAR",4},
+        {"muzzle_snds_m_khk_F", 1},
+        {"rhsgref_30rnd_556x45_vhs2",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,11 +80,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -75,9 +92,9 @@
       },
       "ace_vector"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +104,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,11 +119,11 @@
   class TL: SL {
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -114,9 +131,9 @@
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +142,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,11 +158,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -153,10 +170,10 @@
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -165,11 +182,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -185,11 +202,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -197,10 +214,10 @@
       },
       "Laserdesignator_03"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -209,12 +226,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -224,12 +241,12 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"crab_radiobag_01_wdl_f"};
+    backpack[]={"crab_radiobag_01_tropic_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -238,8 +255,8 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"cup_arifle_mk20",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
+      {"srifle_DMR_03_khaki_F",
+        {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag","ace_acc_pointer_green","optic_ams_khk","rhs_acc_harris_swivel"}
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -247,9 +264,9 @@
       "ace_vector"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -259,9 +276,9 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"optic_tws_mg",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_B",1},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",4},
+	  {"ACE_20Rnd_762x51_Mag_Tracer",4},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -281,7 +298,7 @@
       "ace_yardage450"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"rhsusf_mag_6rnd_m433_hedp",2},
       {"rhsusf_mag_6rnd_m441_he",1},
@@ -307,11 +324,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_cqc_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_G36A_AG36_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","rhsgref_30rnd_556x45_vhs2","CUP_1Rnd_HE_M203"}
         },
-        {"CUP_arifle_Mk17_STD_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_G36K_RIS_AG36_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","rhsgref_30rnd_556x45_vhs2","CUP_1Rnd_HE_M203"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -319,23 +336,24 @@
         }
       };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"cup_1rnd_hedp_m203",12},
-      {"cup_1rnd_he_m203",12},
-      {"rhs_mag_m714_white", 4}
+      {"CUP_1Rnd_HE_M203",12},
+      {"CUP_1Rnd_HEDP_M203",12},
+      {"1_rnd_smoke_grenade_shell", 4}
     };
   };
   class UGL: GN {};
@@ -343,8 +361,8 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -353,11 +371,11 @@
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
-    backpack[]={"b_kitbag_rgr"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -367,11 +385,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -380,11 +398,11 @@
         "ace_vector"
       };
     
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -393,8 +411,8 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -403,10 +421,11 @@
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"Titan_AT", 1}
     };
   };
@@ -415,11 +434,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -428,11 +447,11 @@
       "ace_mx2a"
     };
     
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -444,8 +463,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -466,13 +485,15 @@
   class MED: ME {};
 
   class RM: baseUnit {
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 4},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"150rnd_762x51_box",1},
+	  {"CUP_100Rnd_556x45_BetaCMag",1},	  
+      {"150rnd_762x51_box",1},      
       {"ACE_salineIV_500",1}
     };
   };
@@ -480,8 +501,8 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"cup_lmg_mk48_nohg_tan",
-        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
+      {"CUP_lmg_mk48_nohg_od",
+        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_khk_f"},
       },
       {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
@@ -495,24 +516,48 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_kitbag_rgr"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_h_mg_blk_f",1},
-      {"150rnd_762x51_box",4},
+      {"muzzle_snds_m_khk_F",1},
+      {"150rnd_762x51_box",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class LMG: GPMG {};
+  class MG: GPMG {};
 
-  class MG: GPMG {}; 
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_MG36_wdl",
+        {"CUP_100Rnd_556x45_BetaCMag","ace_acc_pointer_green","optic_Holosight_khk_F"},
+      },
+      {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"CUP_100Rnd_556x45_BetaCMag",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"muzzle_snds_m_khk_F",1},
+      {"CUP_100Rnd_556x45_BetaCMag",4},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
+      {"CUP_arifle_MG36_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","Optic_ERCO_khk_f"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -520,12 +565,12 @@
       "binocular"
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",2},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2",4},
+      {"rhsgref_30rnd_556x45_vhs2_t",2},
       {"SmokeShell",2},
       {"handgrenade",2},
       {"150rnd_762x51_box",2},	  
@@ -536,10 +581,10 @@
   class PT: baseUnit {
 
     weapons[] = {
-      {"cup_smg_mac10_rail",
-        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"}
       },
-      {"CUP_hgun_Duty",
+      {"CUP_hgun_duty",
         {"16rnd_9x21_mag"}
       }
     };
@@ -555,7 +600,7 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhsgref_30rnd_556x45_vhs2",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
@@ -564,7 +609,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhsgref_30rnd_556x45_vhs2",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -589,7 +634,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_carryall_green_f",2}
+      {"B_Bergen_tna_F",2}
     };
   };
   class LargeGearCrate {
@@ -598,12 +643,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",60},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
-      {"150rnd_762x51_box",20},
+      {"rhsgref_30rnd_556x45_vhs2",40},
+      {"rhsgref_30rnd_556x45_vhs2_t",10},
+      {"CUP_100Rnd_556x45_BetaCMag",20},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",10},
+      {"150rnd_762x51_box",8},
+      {"150rnd_762x51_box_tracer",2},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"cup_1rnd_hedp_m203",20},
+      {"CUP_1Rnd_HE_M203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -626,7 +674,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_carryall_green_f",4}
+      {"B_Bergen_tna_F",4}
     };
   };
 };

--- a/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_liz.hpp
+++ b/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_liz.hpp
@@ -1,0 +1,680 @@
+  class CDF_liz {
+    class BaseUnit {
+      ace_earplugs = 1;
+      allowPlayerGoggles = 0;
+      ace_medic = 1;
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        }
+      };
+
+      assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
+
+      headgear[] = {
+        "h_bandanna_khk_hs",
+		"rhsusf_bowman_cap",
+		"h_cap_headphones",
+		"h_cap_oli_hs",
+        "H_Booniehat_khk",
+        "H_MilCap_grn"
+      };
+
+      goggles[] = {
+		"g_bandanna_oli",
+		"rhs_googles_clear",
+        "rhsusf_shemagh_grn",
+        "rhsusf_shemagh2_grn",
+        "rhsusf_shemagh_od",
+        "rhsusf_shemagh2_od",
+        "rhsusf_shemagh_tan",		
+        "rhsusf_shemagh2_tan"
+      };
+
+      uniform[] = {
+        "rhsgref_uniform_altis_lizard",
+        "rhsgref_uniform_altis_lizard_olive"
+      };
+      uniformContents[] = {
+        {"ACE_fieldDressing",4},
+        {"ACE_elasticBandage",4},
+        {"ACE_quikclot",4},
+        {"ACE_morphine",2},
+        {"ACE_adenosine",1},
+        {"ACE_tourniquet",2},
+        {"ACE_Splint",2},
+        {"ACE_salineIV_500",1},
+        {"ACE_Flashlight_XL50",1}
+      };
+
+      vest[] = {V_HarnessO_ghex_F};
+      vestContents[] = {
+        {"rhs_30Rnd_762x39mm_89",6},
+        {"handgrenade",2},
+        {"SmokeShell",2},
+        {"16rnd_9x21_mag",2},
+        {"ace_maptools",1}
+      };
+
+      backpack[] = {"b_viperlightharness_ghex_f"};
+      backpackContents[] = {
+        {"CUP_nvg_pvs7",1},
+        {"rhs_acc_pbs1", 1},
+        {"rhs_30Rnd_762x39mm_89",4},
+        {"SmokeShell",2},
+        {"handgrenade",2}
+      };
+    };
+
+  class SL: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_acc_pso1m21"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_acc_pso1m21"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"acre_prc148",1},
+      {"16rnd_9x21_mag",2},
+      {"itc_land_tablet_rover",1},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"ace_ir_strobe_item",1},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 4},
+      {"SmokeShellGreen", 4},
+      {"ace_microdagr",1}
+    };
+  };
+  class PL: SL {};
+  class ZEUS: SL {};
+  class TL: SL {
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"acre_prc148",1},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"ace_ir_strobe_item",1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 4},
+      {"SmokeShellGreen", 4},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class DFO: SL {
+    assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio","B_UavTerminal"};
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "binocular"
+      };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"acre_prc148",2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"ace_microdagr",1},
+      {"ITC_Land_B_AR2i_Packed",2},
+      {"ACE_UAVBattery",2}
+    };
+  };
+
+  class FSO: DFO {};
+  class FO: DFO {
+    assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "Laserdesignator_03"
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"acre_prc148",1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"laserbatteries",2},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class RTO: baseUnit {
+    backpack[]={"crab_radiobag_01_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"ACRE_PRC117F",1}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_srifle_svd",
+        {"rhs_10Rnd_762x54mmR_7N14","rhs_acc_pso1m2","cup_svd_camo_g"}
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_10Rnd_762x54mmR_7N14",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"CUP_muzzle_snds_KZRZP_SVD",1},
+      {"rhs_10Rnd_762x54mmR_7N14",6},
+	  {"ACE_10Rnd_762x54_Tracer_mag",4},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+  class DMR: DM {};
+
+  class MGL: baseUnit {
+
+    weapons[] = {
+      {"CUP_glaunch_6G30",
+        {"CUP_6Rnd_HE_GP25_M"}
+      },
+        {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"CUP_6Rnd_HE_GP25_M",2},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"CUP_6Rnd_HE_GP25_M",4},
+      {"16rnd_9x21_mag",4},
+      {"handgrenade",2},
+      {"SmokeShell",2}
+    };
+  };
+
+  class GN: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM_gl",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_vog25"}
+        },
+        {"CUP_arifle_AKMS_gl",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_vog25"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        }
+      };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",8},
+      {"handgrenade", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"handgrenade",2},
+      {"rhs_vog25",12},
+      {"rhs_vog25p",8},
+	  {"rhs_vg40tb",4},
+      {"1_rnd_smoke_grenade_shell", 4}
+    };
+  };
+  class UGL: GN {};
+
+  class MAT: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKMS",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      {"rhs_weap_rpg7",
+        {"rhs_rpg7_pg7v_mag"}
+      }
+    };
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7v_mag", 1},
+      {"rhs_rpg7_og7v_mag", 2}
+    };
+  };
+
+  class MATA: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7v_mag", 2},
+      {"rhs_rpg7_og7v_mag", 2}
+    };
+  };
+
+  class HAT: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKMS",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      {"rhs_weap_rpg7",
+        {"rhs_rpg7_og7v_mag"}
+      }
+    };
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7vr_mag", 2},
+      {"rhs_rpg7_og7v_mag", 1}
+    };
+  };
+
+  class HATA: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7vr_mag", 2},
+	  {"rhs_rpg7_og7v_mag",1},
+      {"rhs_rpg7_tbg7v_mag", 1}
+    };
+  };
+
+  class ME: baseUnit {
+    ace_medic = 2;
+    vest[] = {"V_HarnessO_ghex_F"};
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"ACE_fieldDressing",15},
+      {"ACE_packingBandage",10},
+      {"ACE_quikclot",15},
+      {"ACE_elasticBandage",15},
+      {"ACE_morphine",8},
+      {"ACE_epinephrine",8},
+      {"ACE_adenosine",8},
+      {"ACE_salineIV_250",4},
+      {"ACE_salineiv_500",4},
+      {"ACE_salineiv",2},
+      {"ACE_bloodIV",4},
+      {"ACE_personalAidKit",1},
+      {"ACE_surgicalKit",1},
+      {"ACE_splint",8},
+      {"ACE_tourniquet",5}
+    };
+  };
+  class MED: ME {};
+
+  class RM: baseUnit {
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"handgrenade",4},
+      {"SmokeShell",2},
+	  {"rhs_75Rnd_762x39mm_89",1},	  
+      {"150rnd_762x54_box",1},      
+      {"ACE_salineIV_500",1}
+    };
+  };
+  class RF: RM {};
+
+  class GPMG: baseUnit {
+    weapons[] = {
+      {"CUP_lmg_PKMN",
+        {"150rnd_762x54_box","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"150rnd_762x54_box",1},
+      {"16rnd_9x21_mag",3},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+	  {"CUP_muzzle_snds_KZRZP_PK",1},
+      {"150rnd_762x54_box",3},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+  class MG: GPMG {};
+
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_rpk74",
+        {"rhs_75Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"rhs_75Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_75Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
+
+  class GPMGA: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKM",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "binocular"
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89",4},
+      {"rhs_30Rnd_762x39mm_tracer",2},
+      {"SmokeShell",2},
+      {"handgrenade",2},
+      {"150rnd_762x54_box",2},	  
+      {"150rnd_762x54_box_tracer",2}
+    };
+  };
+
+  class PT: baseUnit {
+
+    weapons[] = {
+      {"CUP_smg_Bizon",
+        {"CUP_64Rnd_9x19_Bizon_M","ace_acc_pointer_green"}
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      }
+    };
+
+    headgear[] = {
+      "rhsusf_hgu56p_visor_white",
+      "rhsusf_hgu56p_black",
+      "rhsusf_hgu56p_visor_mask_pink"
+      };
+
+    goggles[] = {rhs_balaclava1_olive};
+
+    vest[] = {"v_tacChestrig_oli_f"};
+    vestContents[] = {
+      {"acre_prc148",1},
+      {"CUP_64Rnd_9x19_Bizon_M",3},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[] = {"b_fieldpack_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"SmokeShell",2},
+      {"CUP_64Rnd_9x19_Bizon_M",3},
+      {"16rnd_9x21_mag",2},	  
+      {"SmokeShellgreen",2},
+      {"handgrenade",2},
+      {"Chemlight_green",2},
+      {"ace_ir_strobe_item",1},
+      {"Toolkit",1},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class PILOT: PT {};
+
+  class LauncherCrate {
+    vehCargoWeapons[] = {
+      {"rhs_weap_rpg26",10},
+	  {"rhs_weap_rshg2",4},
+      {"rhs_weap_rpg7",2},
+      {"ACE_Vector",2}
+    };
+    vehCargoMagazines[] = {
+      {"rhs_rpg7_og7v_mag",6},
+      {"rhs_rpg7_pg7v_mag",6},
+	  {"rhs_rpg7_tbg7v_mag",6},
+      {"rhs_rpg7_pg7vr_mag",6}
+    };
+    vehCargoRucks[] = {
+      {"b_carryall_ghex_f",2}
+    };
+  };
+  class LargeGearCrate {
+    vehCargoWeapons[] = {
+      {"rhs_weap_rpg26",6},
+      {"ACE_Vector",2}
+    };
+    vehCargoMagazines[] = {
+      {"rhs_30Rnd_762x39mm_89",40},
+      {"rhs_30Rnd_762x39mm_tracer",10},
+      {"rhs_75Rnd_762x39mm_89",20},
+      {"rhs_10Rnd_762x54mmR_7N14",10},
+      {"150rnd_762x54_box",8},
+      {"150rnd_762x54_box_tracer",2},
+      {"handgrenade",20},
+      {"SmokeShell",10},
+      {"rhs_vog25",15},
+	  {"rhs_vog25p",15},
+	  {"rhs_vg40tb",10},
+      {"DemoCharge_Remote_Mag",8}
+    };
+    vehCargoItems[] = {
+      {"ToolKit",1},
+      {"ACE_M26_Clacker",4},
+      {"ACE_DefusalKit",2},
+      {"ACE_fieldDressing",20},
+      {"ACE_packingBandage",20},
+      {"ACE_quikclot",20},
+      {"ACE_Tourniquet",8},
+      {"ACE_splint",4},
+      {"ACE_morphine",4},
+      {"ACE_epinephrine",4},
+      {"ACE_adenosine",4},
+      {"ACE_salineIV",4},      
+      {"ACE_salineIV_500",4},
+      {"ACE_Flashlight_MX991",4},
+      {"ACE_MapTools",4}
+    };
+    vehCargoRucks[] = {
+      {"b_carryall_ghex_f",4}
+    };
+  };
+};

--- a/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_rus.hpp
+++ b/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_rus.hpp
@@ -1,4 +1,4 @@
-  class CDF_des {
+  class CDF_rus {
     class BaseUnit {
       ace_earplugs = 1;
       allowPlayerGoggles = 0;
@@ -6,28 +6,35 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         }
       };
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhs_booniehat2_marpatd"};
+      headgear[] = {
+        "H_HelmetAggressor_cover_F",
+        "H_HelmetAggressor_F"
+      };
 
       goggles[] = {
+        "rhsusf_shemagh_gogg_grn",
+        "rhsusf_shemagh2_gogg_grn",
+        "rhsusf_shemagh_gogg_od",
+        "rhsusf_shemagh2_gogg_od",
         "rhsusf_shemagh_gogg_tan",		
         "rhsusf_shemagh2_gogg_tan"
       };
 
-      uniform[] = {"rhs_uniform_emr_des_patchless"};
+      uniform[] = {"U_O_R_Gorka_01_F"};
       uniformContents[] = {
         {"ACE_fieldDressing",4},
         {"ACE_elasticBandage",4},
@@ -40,9 +47,9 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {v_tacchestrig_grn_f};
+      vest[] = {V_CarrierRigKBT_01_light_Olive_F};
       vestContents[] = {
-        {"CUP_20Rnd_762x51_B_SCAR",6},
+        {"rhs_30Rnd_545x39_7N22_AK",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
@@ -52,8 +59,8 @@
       backpack[] = {"b_kitbag_rgr"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsgref_sdn6_silencer", 1},
-        {"CUP_20Rnd_762x51_B_SCAR",4},
+        {"rhs_acc_dtk4short", 1},
+        {"rhs_30Rnd_545x39_7N22_AK",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,21 +70,21 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","rhsusf_acc_su230","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","rhsusf_acc_su230","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +94,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,21 +109,21 @@
   class TL: SL {
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +132,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,22 +148,22 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -168,8 +175,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -185,22 +192,22 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -212,9 +219,9 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -227,9 +234,9 @@
     backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -238,18 +245,18 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"cup_arifle_mk20",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
+      {"srifle_DMR_05_blk_F",
+        {"10Rnd_93x64_DMR_05_Mag","ace_acc_pointer_green","optic_ams","rhs_acc_harris_swivel"}
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"10Rnd_93x64_DMR_05_Mag",5},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -259,9 +266,8 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"optic_tws_mg",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_93mmg",1},
+      {"10Rnd_93x64_DMR_05_Mag",5},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -272,19 +278,18 @@
   class MGL: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m32",
-        {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
+      {"CUP_glaunch_6G30",
+        {"CUP_6Rnd_HE_GP25_M"}
       },
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"rhsusf_mag_6rnd_m433_hedp",2},
-      {"rhsusf_mag_6rnd_m441_he",1},
+      {"CUP_6Rnd_HE_GP25_M",2},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -294,9 +299,7 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_mag_6rnd_m433_hedp",2},
-      {"rhsusf_mag_6rnd_m441_he",1},
-      {"rhsusf_mag_6rnd_m714_white",2},
+      {"CUP_6Rnd_HE_GP25_M",4},
       {"16rnd_9x21_mag",4},
       {"handgrenade",2},
       {"SmokeShell",2}
@@ -307,21 +310,21 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_cqc_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_AK107_GL_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_vog25","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_AK74M_GL_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_vog25","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         }
       };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -329,13 +332,14 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"cup_1rnd_hedp_m203",12},
-      {"cup_1rnd_he_m203",12},
-      {"rhs_mag_m714_white", 4}
+      {"rhs_vog25",12},
+      {"rhs_vog25p",8},
+      {"rhs_vg25tb",4},
+      {"rhs_vg40md", 4}
     };
   };
   class UGL: GN {};
@@ -343,23 +347,23 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_AK105_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
-      {"launch_MRAWS_green_rail_F",
-        {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
+      {"launch_RPG32_green_F",
+        {"RPG32_F", "ace_acc_pointer_green"}
       }
     };
     backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
-      {"MRAWS_HEAT55_F", 1},
-      {"MRAWS_HE_F", 2}
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
+      {"RPG32_F", 1},
+      {"RPG32_HE_F", 2}
     };
   };
 
@@ -367,14 +371,14 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
@@ -383,30 +387,30 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
-      {"MRAWS_HEAT55_F", 2},
-      {"MRAWS_HE_F", 2}
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
+      {"RPG32_F", 2},
+      {"RPG32_HE_F", 2}
     };
   };
 
   class HAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_AK105_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
-      {"launch_o_titan_short_f",
+      {"launch_I_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
       {"Titan_AT", 1}
     };
   };
@@ -415,14 +419,14 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_mx2a"
@@ -431,8 +435,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -440,12 +444,12 @@
 
   class ME: baseUnit {
     ace_medic = 2;
-    vest[] = {"V_SmershVest_01_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -468,11 +472,11 @@
   class RM: baseUnit {
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 4},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"150rnd_762x51_box",1},
+      {"150rnd_762x54_box",1},      
       {"ACE_salineIV_500",1}
     };
   };
@@ -480,17 +484,17 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"cup_lmg_mk48_nohg_tan",
-        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
+      {"CUP_lmg_Pecheneg",
+        {"150rnd_762x54_box","ace_acc_pointer_green","rhs_acc_ekp8_02d"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
       }
     };
-    vest[] = {"V_SmershVest_01_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"150rnd_762x51_box",1},
+      {"150rnd_762x54_box",1},
       {"16rnd_9x21_mag",3},
       {"ace_maptools",1}
     };
@@ -498,23 +502,47 @@
     backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_h_mg_blk_f",1},
-      {"150rnd_762x51_box",4},
+      {"CUP_muzzle_snds_KZRZP_PK",1},
+      {"150rnd_762x54_box",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class LMG: GPMG {};
+  class MG: GPMG {};
 
-  class MG: GPMG {}; 
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_RPK74M_railed",
+        {"CUP_60Rnd_545x39_AK74M_M","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"CUP_60Rnd_545x39_AK74M_M",4},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"rhs_acc_dtk4short",1},
+      {"CUP_60Rnd_545x39_AK74M_M",8},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
+      {"CUP_arifle_AK107_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "binocular"
@@ -523,23 +551,23 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",2},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK",4},
+      {"rhs_30Rnd_545x39_AK_green",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"150rnd_762x51_box",2},	  
-      {"150rnd_762x51_box_tracer",2}
+      {"150rnd_762x54_box",2},	  
+      {"150rnd_762x54_box_tracer",1}
     };
   };
 
   class PT: baseUnit {
 
     weapons[] = {
-      {"cup_smg_mac10_rail",
-        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      {"CUP_arifle_AKS74U_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"}
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       }
     };
@@ -555,7 +583,7 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhs_30Rnd_545x39_7N22_AK",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
@@ -564,7 +592,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhs_30Rnd_545x39_7N22_AK",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -598,12 +626,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",60},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
-      {"150rnd_762x51_box",20},
+      {"rhs_30Rnd_545x39_7N22_AK",40},
+      {"rhs_30Rnd_545x39_AK_green",10},
+      {"CUP_60Rnd_545x39_AK74M_M",20},
+      {"10Rnd_93x64_DMR_05_Mag",10},
+      {"150rnd_762x54_box",8},
+      {"150rnd_762x54_box_tracer",2},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"cup_1rnd_hedp_m203",20},
+      {"rhs_vog25",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}

--- a/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_wdl.hpp
+++ b/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/cdf_wdl.hpp
@@ -4,11 +4,16 @@
       allowPlayerGoggles = 0;
       ace_medic = 1;
 
-      weapons[] = {
-        {"rhs_weap_m16a4_imod_grip",
-          {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"}
+    weapons[] = {
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
         },
-        {"hgun_p07_khk_f",
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
@@ -47,7 +52,7 @@
 
       vest[] = {V_SmershVest_01_F};
       vestContents[] = {
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+        {"CUP_30Rnd_556x45_Emag",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
@@ -58,7 +63,7 @@
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
         {"rhsusf_acc_rotex5_grey", 1},
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+        {"CUP_30Rnd_556x45_Emag",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -67,17 +72,22 @@
   class SL: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "rhsusf_acc_su230","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -89,7 +99,7 @@
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -101,17 +111,22 @@
   class ZEUS: SL {};
   class TL: SL {
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -123,7 +138,7 @@
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -135,18 +150,23 @@
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio","B_UavTerminal"};
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -155,11 +175,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -168,15 +188,21 @@
       {"ACE_UAVBattery",2}
     };
   };
+
   class FSO: DFO {};
   class FO: DFO {
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
@@ -184,7 +210,7 @@
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -193,12 +219,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -208,32 +234,31 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
   };
 
-  class DM: baseUnit {
+  class HRF: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_sr25_ec",
-        {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a","rhsusf_acc_harris_bipod"}
+      {"CUP_arifle_Mk17_CQC_SFG_woodland",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_tws_mg"}
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
     };
 
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",6},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -242,9 +267,43 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
       {"rhsgref_sdn6_silencer",1},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",4},
-      {"rhsusf_20Rnd_762x51_sr25_M62_Mag",2},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_arifle_mk20_woodland",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_ams_khk","bipod_02_f_lush"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_vector"
+    };
+
+    vest[] = {"V_SmershVest_01_radio_F"};
+    vestContents[] = {
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -258,7 +317,7 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_khk_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
@@ -274,7 +333,7 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_mag_6rnd_m433_hedp",2},
@@ -289,17 +348,22 @@
   class GN: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_M203",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      }
-    };
+      {
+        {"CUP_arifle_Mk16_STD_EGLM_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag","cup_1rnd_hedp_m203"}
+        },
+        {"CUP_arifle_Mk16_CQC_EGLM_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag","cup_1rnd_hedp_m203"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        }
+      };
 
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",8},
+      {"CUP_30Rnd_556x45_Emag",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -308,11 +372,11 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhs_mag_m433_hedp",12},
-      {"rhs_mag_m441_he",12},
+      {"cup_1rnd_hedp_m203",12},
+      {"cup_1rnd_he_m203",12},
       {"rhs_mag_m714_white", 4}
     };
   };
@@ -321,10 +385,10 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
+      {"CUP_arifle_Mk16_CQC_FG_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
@@ -335,7 +399,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -344,20 +408,25 @@
   class MATA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -366,10 +435,10 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
+      {"CUP_arifle_Mk16_CQC_FG_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
@@ -379,7 +448,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"Titan_AT", 1}
     };
   };
@@ -387,20 +456,25 @@
   class HATA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
+      "ace_mx2a"
     };
     
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -409,11 +483,11 @@
   class ME: baseUnit {
     ace_medic = 2;
     vest[] = {"V_SmershVest_01_F"};
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -437,10 +511,10 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 6},
+      {"CUP_30Rnd_556x45_Emag", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote",1},
+      {"150Rnd_556x45_Drum_Green_Mag_f",1},
       {"ACE_salineIV_500",1}
     };
   };
@@ -448,25 +522,26 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_m60e4",
+        {"rhsusf_100Rnd_762x51_m61_ap","ace_acc_pointer_green","Optic_ERCO_blk_f"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"o_nvgoggles_grn_f",1},
+      {"rhsusf_100Rnd_762x51_m61_ap",3},
       {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
     backpack[]={"b_kitbag_sgg"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"rhsusf_100Rnd_762x51_m61_ap",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
@@ -476,15 +551,15 @@
   class LMG: baseUnit {
  
     weapons[] = {
-      {"rhs_weap_m249_light_S_vfg2",
-        {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote","rhsusf_acc_anpeq15side_bk","optic_Holosight_blk_F","rhsusf_acc_grip4_bipod"},
+      {"CUP_arifle_Mk16_SV_woodland",
+        {"150Rnd_556x45_Drum_Green_Mag_F","ace_acc_pointer_green","optic_Holosight_khk_F","bipod_02_F_lush"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vestContents[] = {
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",2},
+      {"150Rnd_556x45_Drum_Green_Mag_F",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
       {"handgrenade",2},
@@ -492,8 +567,9 @@
     };
 
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",4},
+      {"150Rnd_556x45_Drum_Green_Mag_F",6},
       {"SmokeShell",2},
       {"handgrenade",2}
     };   
@@ -502,23 +578,24 @@
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F"},
+      {"CUP_arifle_Mk16_SV_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F","bipod_02_F_lush"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
+      {"rhsusf_100Rnd_762x51_m61_ap",4},	  
       {"rhsusf_100Rnd_762x51_m62_tracer",2}
     };
   };
@@ -526,11 +603,11 @@
   class PT: baseUnit {
 
     weapons[] = {
-      {"smg_03c_tr_black",
-        {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
+      {"cup_smg_mac10_rail",
+        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
       },
-      {"hgun_p07_khk_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       }
     };
 
@@ -545,15 +622,16 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"50rnd_570x28_smg_03",2},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
-    backpack[] = {"b_tacticalpack_oli"};
+    backpack[] = {"b_fieldpack_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"50rnd_570x28_smg_03",4},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -563,7 +641,9 @@
       {"ace_microdagr",1}
     };
   };
+
   class PILOT: PT {};
+
   class LauncherCrate {
     vehCargoWeapons[] = {
       {"rhs_weap_m72a7",10},
@@ -576,7 +656,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_fieldpack_green_f",2}
+      {"b_carryall_green_f",2}
     };
   };
   class LargeGearCrate {
@@ -585,15 +665,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",40},
+      {"CUP_30Rnd_556x45_Emag",40},
       {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",10},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",10},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",10},
-      {"rhsusf_20Rnd_762x51_SR25_m62_Mag",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
+      {"150Rnd_556x45_Drum_Green_Mag_F",10},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",10},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",4},
+      {"rhsusf_100Rnd_762x51_m61_ap",8},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"rhs_mag_m433_hedp",20},
+      {"cup_1rnd_hedp_m203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -616,7 +696,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_carryall_oli",4}
+      {"b_carryall_green_f",4}
     };
   };
 };

--- a/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/loadouts.hpp
+++ b/CO18_CZ_Kunduz_V29.Kunduz/tb3/murk/loadouts.hpp
@@ -1,3 +1,6 @@
 #include "cdf_blk.hpp"
 #include "cdf_des.hpp"
 #include "cdf_wdl.hpp"
+#include "cdf_rus.hpp"
+#include "cdf_liz.hpp"
+#include "cdf_jng.hpp"

--- a/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_blk.hpp
+++ b/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_blk.hpp
@@ -8,7 +8,7 @@
         {"arifle_msbs65_black_f",
           {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"}
         },
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
@@ -61,7 +61,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_erco_blk_f",},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -95,7 +95,7 @@
       {"arifle_msbs65_ubs_black_f",
         {"30rnd_65x39_caseless_msbs_mag","6rnd_12gauge_pellets","ace_acc_pointer_green", "optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -131,7 +131,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -152,10 +152,10 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
-      {"30rnd_65x39_caseless_msbs_mag",6},
+      {"30rnd_65x39_caseless_msbs_mag",4},
       {"SmokeShell",2},
-      {"SmokeshellRed", 2},
-      {"SmokeShellGreen", 2},
+      {"SmokeshellRed", 1},
+      {"SmokeShellGreen", 1},
       {"ace_microdagr",1},
       {"ITC_Land_B_AR2i_Packed",2},
       {"ACE_UAVBattery",2}
@@ -169,7 +169,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_Holosight_blk_F",},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
@@ -201,7 +201,7 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"crab_radiobag_01_black_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
@@ -212,21 +212,20 @@
     };
   };
 
-  class DM: baseUnit {
+  class HRF: baseUnit {
 
     weapons[] = {
-      {"srifle_dmr_03_f",
-        {"ace_20rnd_762x51_mk319_mod_0_mag","ace_acc_pointer_green","rhsusf_acc_su230a","rhs_acc_harris_swivel"}
+      {"CUP_arifle_Mk17_CQC_SFG_black",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_tws_mg"}
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
     };
 
-    vest[] = {"V_platecarrier2_blk"};
+    vest[] = {"V_platecarrier1_blk"};
     vestContents[] = {
-      {"ace_20rnd_762x51_mk319_mod_0_mag",6},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -235,9 +234,43 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_b",1},
-      {"ace_20rnd_762x51_mk319_mod_0_mag",4},
-      {"ace_20rnd_762x51_mag_tracer",2},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_arifle_mk20_black",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_ams","bipod_02_f_blk"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_vector"
+    };
+
+    vest[] = {"V_platecarrier1_blk"};
+    vestContents[] = {
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -251,7 +284,7 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
@@ -279,13 +312,44 @@
     };
   };
 
+  class SMG: baseUnit {
+
+    weapons[] = {
+      {"rhsusf_weap_mp7a2",
+        {"rhsusf_mag_40rnd_46x30_jhp","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      }
+    };
+
+    vest[] = {"V_platecarrier1_blk"};
+    vestContents[] = {
+      {"rhsusf_mag_40rnd_46x30_jhp",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_viperlightharness_blk_f"};
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"rhsusf_mag_40rnd_46x30_jhp",6},
+      {"ace_cts9",2},
+      {"ace_m84",2},
+      {"16rnd_9x21_mag",4},
+      {"handgrenade",4}
+    };
+  };
+
   class GN: baseUnit {
 
     weapons[] = {
       {"arifle_msbs65_gl_black_f",
         {"30rnd_65x39_caseless_msbs_mag", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F", "rhsusf_acc_grip1"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       }
     };
@@ -317,13 +381,15 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
+    vest[] = {"V_tacvestir_blk"};
+
     backpack[]={"b_viperlightharness_blk_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
@@ -340,7 +406,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -362,13 +428,15 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
+    vest[] = {"V_tacvestir_blk"};
+
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f",1},
@@ -383,7 +451,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -406,7 +474,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
-      {"30rnd_65x39_caseless_msbs_mag",6},
+      {"30rnd_65x39_caseless_msbs_mag",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -441,25 +509,25 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_mk48_nohg",
+        {"150rnd_762x51_box","rhsusf_acc_anpeq15side_bk","Optic_ERCO_blk_f"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vest[] = {"V_tacvestir_blk"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
-      {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
+      {"150rnd_762x51_box",2},
+      {"16rnd_9x21_mag",1},
       {"ace_maptools",1}
     };
 
     backpack[]={"b_viperlightharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_black_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"150rnd_762x51_box",4},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
@@ -472,7 +540,7 @@
       {"lmg_mk200_black_f",
         {"200rnd_65x39_cased_box","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_harris_swivel"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
@@ -480,11 +548,11 @@
     vestContents[] = {
       {"200rnd_65x39_cased_box",2},
       {"16rnd_9x21_mag",2},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
       {"200rnd_65x39_cased_box",4},
       {"SmokeShell",2},
@@ -498,7 +566,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
@@ -506,13 +574,14 @@
 
     backpack[]={"b_viperharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f",1},
       {"30rnd_65x39_caseless_msbs_mag",4},
       {"30rnd_65x39_caseless_msbs_mag_tracer",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
-      {"rhsusf_100Rnd_762x51_m62_tracer",2}
+      {"150rnd_762x51_box",2},	  
+      {"150rnd_762x51_box_tracer",2}
     };
   };
 
@@ -522,7 +591,7 @@
       {"smg_03c_tr_black",
         {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
@@ -543,6 +612,7 @@
 
     backpack[] = {"b_viperharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
       {"50rnd_570x28_smg_03",4},
       {"16rnd_9x21_mag",2},	  
@@ -581,8 +651,8 @@
       {"200rnd_65x39_cased_box",10},
       {"ace_20rnd_762x51_mk319_mod_0_mag",10},
       {"ace_20rnd_762x51_mag_tracer",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
-      {"rhsusf_100Rnd_762x51_m62_tracer",4},
+      {"150rnd_762x51_box",8},
+      {"150rnd_762x51_box_tracer",4},
       {"handgrenade",20},
       {"SmokeShell",10},
       {"rhs_mag_m433_hedp",20},

--- a/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_des.hpp
+++ b/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_des.hpp
@@ -6,21 +6,21 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhsusf_protech_helmet_rhino"};
+      headgear[] = {"rhs_booniehat2_marpatd"};
 
       goggles[] = {
         "rhsusf_shemagh_gogg_tan",		
@@ -40,20 +40,20 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {V_platecarrier1_blk};
+      vest[] = {v_tacchestrig_grn_f};
       vestContents[] = {
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+        {"CUP_20Rnd_762x51_B_SCAR",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
         {"ace_maptools",1}
       };
 
-      backpack[] = {"b_viperlightharness_blk_f"};
+      backpack[] = {"b_kitbag_rgr"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsusf_acc_rotex5_grey", 1},
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+        {"rhsgref_sdn6_silencer", 1},
+        {"CUP_20Rnd_762x51_B_SCAR",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,21 +63,21 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +87,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,21 +102,21 @@
   class TL: SL {
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
-    vest[] = {"V_platecarrier1_blk"};
+        },
+        "ace_vector"
+      };
+    vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +125,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,22 +141,22 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
-    vest[] = {"V_platecarrier1_blk"};
+        },
+        "ace_vector"
+      };
+    vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -165,11 +165,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -178,28 +178,29 @@
       {"ACE_UAVBattery",2}
     };
   };
+
   class FSO: DFO {};
   class FO: DFO {
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
     weapons[] = {
       {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+        {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
     };
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -208,12 +209,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -223,12 +224,12 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -237,18 +238,18 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_sr25_ec_d",
-        {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a","rhsusf_acc_harris_bipod"}
+      {"cup_arifle_mk20",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -257,9 +258,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
       {"rhsgref_sdn6_silencer",1},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",4},
-      {"rhsusf_20Rnd_762x51_sr25_M62_Mag",2},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -273,13 +275,13 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
     };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
       {"rhsusf_mag_6rnd_m433_hedp",2},
       {"rhsusf_mag_6rnd_m441_he",1},
@@ -289,7 +291,7 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_mag_6rnd_m433_hedp",2},
@@ -304,17 +306,22 @@
   class GN: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m4a1_M203s_d",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F"},
-      },
-      {"hgun_p07_f",
-        {"16rnd_9x21_mag"}
-      }
-    };
+      {
+        {"CUP_arifle_Mk17_cqc_EGLM",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        },
+        {"CUP_arifle_Mk17_STD_EGLM",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        }
+      };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",8},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -322,12 +329,12 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhs_mag_m433_hedp",12},
-      {"rhs_mag_m441_he",12},
+      {"cup_1rnd_hedp_m203",12},
+      {"cup_1rnd_he_m203",12},
       {"rhs_mag_m714_white", 4}
     };
   };
@@ -336,26 +343,21 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        }
-      },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
-    backpack[]={"b_viperlightharness_blk_f"};
+    backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -365,24 +367,24 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+        },
+        "ace_vector"
+      };
     
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -391,16 +393,11 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        }
-      },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
@@ -408,8 +405,8 @@
     };
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"Titan_AT", 1}
     };
   };
@@ -418,24 +415,24 @@
 
     weapons[] = {
       {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+        {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
-      "ace_vector"
+      "ace_mx2a"
     };
     
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -443,12 +440,12 @@
 
   class ME: baseUnit {
     ace_medic = 2;
-    vest[] = {"V_tacvestir_blk"};
-    backpack[]={"b_viperharness_blk_f"};
+    vest[] = {"V_SmershVest_01_F"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -471,11 +468,11 @@
   class RM: baseUnit {
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 6},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 4},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote",1},
+      {"150rnd_762x51_box",1},
       {"ACE_salineIV_500",1}
     };
   };
@@ -483,89 +480,67 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_mk48_nohg_tan",
+        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
-    vest[] = {"V_tacvestir_blk"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"o_nvgoggles_grn_f",1},
+      {"150rnd_762x51_box",1},
       {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperlightharness_blk_f"};
+    backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"150rnd_762x51_box",4},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class MG: GPMG {};
+  class LMG: GPMG {};
 
-  class LMG: baseUnit {
- 
-    weapons[] = {
-      {"rhs_weap_m249_light_S_vfg2",
-        {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote","rhsusf_acc_anpeq15side_bk","optic_Holosight_blk_F","rhsusf_acc_grip4_bipod"},
-      },
-      {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
-      }
-    };
-    vestContents[] = {
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",2},
-      {"SmokeShell",2},
-      {"16rnd_9x21_mag",2},
-      {"handgrenade",2},
-      {"ace_maptools",1}
-    };
-
-    backpackContents[] = {
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",4},
-      {"SmokeShell",2},
-      {"handgrenade",2}
-    };   
-  };
+  class MG: GPMG {}; 
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F"},
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
-      {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",2},
+      {"o_nvgoggles_grn_f",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR",2},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
-      {"rhsusf_100Rnd_762x51_m62_tracer",2}
+      {"150rnd_762x51_box",2},	  
+      {"150rnd_762x51_box_tracer",2}
     };
   };
 
   class PT: baseUnit {
 
     weapons[] = {
-      {"smg_03c_tr_black",
-        {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
+      {"cup_smg_mac10_rail",
+        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
       },
-      {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       }
     };
 
@@ -580,15 +555,16 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"50rnd_570x28_smg_03",2},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
-    backpack[] = {"b_tacticalpack_oli"};
+    backpack[] = {"b_fieldpack_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"50rnd_570x28_smg_03",4},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -598,7 +574,9 @@
       {"ace_microdagr",1}
     };
   };
+
   class PILOT: PT {};
+
   class LauncherCrate {
     vehCargoWeapons[] = {
       {"rhs_weap_m72a7",10},
@@ -611,7 +589,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_fieldpack_green_f",2}
+      {"b_carryall_green_f",2}
     };
   };
   class LargeGearCrate {
@@ -620,15 +598,12 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",40},
-      {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",10},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",10},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",10},
-      {"rhsusf_20Rnd_762x51_SR25_m62_Mag",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
+      {"CUP_20Rnd_762x51_B_SCAR",60},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
+      {"150rnd_762x51_box",20},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"rhs_mag_m433_hedp",20},
+      {"cup_1rnd_hedp_m203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -651,7 +626,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_viperharness_blk_f",4}
+      {"b_carryall_green_f",4}
     };
   };
 };

--- a/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_jng.hpp
+++ b/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_jng.hpp
@@ -1,4 +1,4 @@
-  class CDF_des {
+  class CDF_jng {
     class BaseUnit {
       ace_earplugs = 1;
       allowPlayerGoggles = 0;
@@ -6,11 +6,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -20,14 +20,31 @@
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhs_booniehat2_marpatd"};
-
-      goggles[] = {
-        "rhsusf_shemagh_gogg_tan",		
-        "rhsusf_shemagh2_gogg_tan"
+      headgear[] = {
+        "h_bandanna_khk_hs",
+		"rhsusf_bowman_cap",
+		"h_cap_headphones",
+		"h_cap_oli_hs",
+        "H_Booniehat_tna_F",
+        "H_MilCap_tna_F"
       };
 
-      uniform[] = {"rhs_uniform_emr_des_patchless"};
+      goggles[] = {
+		"g_bandanna_oli",
+		"rhs_googles_clear",
+        "rhsusf_shemagh_grn",
+        "rhsusf_shemagh2_grn",
+        "rhsusf_shemagh_od",
+        "rhsusf_shemagh2_od",
+        "rhsusf_shemagh_tan",		
+        "rhsusf_shemagh2_tan"
+      };
+
+      uniform[] = {
+        "U_B_T_Soldier_F",
+        "U_B_T_Soldier_AR_F",
+        "U_B_T_Soldier_SL_F"
+      };
       uniformContents[] = {
         {"ACE_fieldDressing",4},
         {"ACE_elasticBandage",4},
@@ -40,20 +57,20 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {v_tacchestrig_grn_f};
+      vest[] = {V_SmershVest_01_F};
       vestContents[] = {
-        {"CUP_20Rnd_762x51_B_SCAR",6},
+        {"rhsgref_30rnd_556x45_vhs2",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
         {"ace_maptools",1}
       };
 
-      backpack[] = {"b_kitbag_rgr"};
+      backpack[] = {"b_carryall_green_f"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsgref_sdn6_silencer", 1},
-        {"CUP_20Rnd_762x51_B_SCAR",4},
+        {"muzzle_snds_m_khk_F", 1},
+        {"rhsgref_30rnd_556x45_vhs2",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,11 +80,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -75,9 +92,9 @@
       },
       "ace_vector"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +104,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,11 +119,11 @@
   class TL: SL {
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -114,9 +131,9 @@
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +142,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,11 +158,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -153,10 +170,10 @@
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -165,11 +182,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -185,11 +202,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -197,10 +214,10 @@
       },
       "Laserdesignator_03"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -209,12 +226,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -224,12 +241,12 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"crab_radiobag_01_wdl_f"};
+    backpack[]={"crab_radiobag_01_tropic_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -238,8 +255,8 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"cup_arifle_mk20",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
+      {"srifle_DMR_03_khaki_F",
+        {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag","ace_acc_pointer_green","optic_ams_khk","rhs_acc_harris_swivel"}
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -247,9 +264,9 @@
       "ace_vector"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -259,9 +276,9 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"optic_tws_mg",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_B",1},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",4},
+	  {"ACE_20Rnd_762x51_Mag_Tracer",4},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -281,7 +298,7 @@
       "ace_yardage450"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"rhsusf_mag_6rnd_m433_hedp",2},
       {"rhsusf_mag_6rnd_m441_he",1},
@@ -307,11 +324,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_cqc_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_G36A_AG36_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","rhsgref_30rnd_556x45_vhs2","CUP_1Rnd_HE_M203"}
         },
-        {"CUP_arifle_Mk17_STD_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_G36K_RIS_AG36_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","rhsgref_30rnd_556x45_vhs2","CUP_1Rnd_HE_M203"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -319,23 +336,24 @@
         }
       };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"cup_1rnd_hedp_m203",12},
-      {"cup_1rnd_he_m203",12},
-      {"rhs_mag_m714_white", 4}
+      {"CUP_1Rnd_HE_M203",12},
+      {"CUP_1Rnd_HEDP_M203",12},
+      {"1_rnd_smoke_grenade_shell", 4}
     };
   };
   class UGL: GN {};
@@ -343,8 +361,8 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -353,11 +371,11 @@
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
-    backpack[]={"b_kitbag_rgr"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -367,11 +385,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -380,11 +398,11 @@
         "ace_vector"
       };
     
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -393,8 +411,8 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -403,10 +421,11 @@
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"Titan_AT", 1}
     };
   };
@@ -415,11 +434,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -428,11 +447,11 @@
       "ace_mx2a"
     };
     
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -444,8 +463,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -466,13 +485,15 @@
   class MED: ME {};
 
   class RM: baseUnit {
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 4},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"150rnd_762x51_box",1},
+	  {"CUP_100Rnd_556x45_BetaCMag",1},	  
+      {"150rnd_762x51_box",1},      
       {"ACE_salineIV_500",1}
     };
   };
@@ -480,8 +501,8 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"cup_lmg_mk48_nohg_tan",
-        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
+      {"CUP_lmg_mk48_nohg_od",
+        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_khk_f"},
       },
       {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
@@ -495,24 +516,48 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_kitbag_rgr"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_h_mg_blk_f",1},
-      {"150rnd_762x51_box",4},
+      {"muzzle_snds_m_khk_F",1},
+      {"150rnd_762x51_box",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class LMG: GPMG {};
+  class MG: GPMG {};
 
-  class MG: GPMG {}; 
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_MG36_wdl",
+        {"CUP_100Rnd_556x45_BetaCMag","ace_acc_pointer_green","optic_Holosight_khk_F"},
+      },
+      {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"CUP_100Rnd_556x45_BetaCMag",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"muzzle_snds_m_khk_F",1},
+      {"CUP_100Rnd_556x45_BetaCMag",4},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
+      {"CUP_arifle_MG36_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","Optic_ERCO_khk_f"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -520,12 +565,12 @@
       "binocular"
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",2},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2",4},
+      {"rhsgref_30rnd_556x45_vhs2_t",2},
       {"SmokeShell",2},
       {"handgrenade",2},
       {"150rnd_762x51_box",2},	  
@@ -536,10 +581,10 @@
   class PT: baseUnit {
 
     weapons[] = {
-      {"cup_smg_mac10_rail",
-        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"}
       },
-      {"CUP_hgun_Duty",
+      {"CUP_hgun_duty",
         {"16rnd_9x21_mag"}
       }
     };
@@ -555,7 +600,7 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhsgref_30rnd_556x45_vhs2",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
@@ -564,7 +609,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhsgref_30rnd_556x45_vhs2",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -589,7 +634,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_carryall_green_f",2}
+      {"B_Bergen_tna_F",2}
     };
   };
   class LargeGearCrate {
@@ -598,12 +643,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",60},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
-      {"150rnd_762x51_box",20},
+      {"rhsgref_30rnd_556x45_vhs2",40},
+      {"rhsgref_30rnd_556x45_vhs2_t",10},
+      {"CUP_100Rnd_556x45_BetaCMag",20},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",10},
+      {"150rnd_762x51_box",8},
+      {"150rnd_762x51_box_tracer",2},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"cup_1rnd_hedp_m203",20},
+      {"CUP_1Rnd_HE_M203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -626,7 +674,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_carryall_green_f",4}
+      {"B_Bergen_tna_F",4}
     };
   };
 };

--- a/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_liz.hpp
+++ b/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_liz.hpp
@@ -1,0 +1,680 @@
+  class CDF_liz {
+    class BaseUnit {
+      ace_earplugs = 1;
+      allowPlayerGoggles = 0;
+      ace_medic = 1;
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        }
+      };
+
+      assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
+
+      headgear[] = {
+        "h_bandanna_khk_hs",
+		"rhsusf_bowman_cap",
+		"h_cap_headphones",
+		"h_cap_oli_hs",
+        "H_Booniehat_khk",
+        "H_MilCap_grn"
+      };
+
+      goggles[] = {
+		"g_bandanna_oli",
+		"rhs_googles_clear",
+        "rhsusf_shemagh_grn",
+        "rhsusf_shemagh2_grn",
+        "rhsusf_shemagh_od",
+        "rhsusf_shemagh2_od",
+        "rhsusf_shemagh_tan",		
+        "rhsusf_shemagh2_tan"
+      };
+
+      uniform[] = {
+        "rhsgref_uniform_altis_lizard",
+        "rhsgref_uniform_altis_lizard_olive"
+      };
+      uniformContents[] = {
+        {"ACE_fieldDressing",4},
+        {"ACE_elasticBandage",4},
+        {"ACE_quikclot",4},
+        {"ACE_morphine",2},
+        {"ACE_adenosine",1},
+        {"ACE_tourniquet",2},
+        {"ACE_Splint",2},
+        {"ACE_salineIV_500",1},
+        {"ACE_Flashlight_XL50",1}
+      };
+
+      vest[] = {V_HarnessO_ghex_F};
+      vestContents[] = {
+        {"rhs_30Rnd_762x39mm_89",6},
+        {"handgrenade",2},
+        {"SmokeShell",2},
+        {"16rnd_9x21_mag",2},
+        {"ace_maptools",1}
+      };
+
+      backpack[] = {"b_viperlightharness_ghex_f"};
+      backpackContents[] = {
+        {"CUP_nvg_pvs7",1},
+        {"rhs_acc_pbs1", 1},
+        {"rhs_30Rnd_762x39mm_89",4},
+        {"SmokeShell",2},
+        {"handgrenade",2}
+      };
+    };
+
+  class SL: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_acc_pso1m21"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_acc_pso1m21"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"acre_prc148",1},
+      {"16rnd_9x21_mag",2},
+      {"itc_land_tablet_rover",1},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"ace_ir_strobe_item",1},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 4},
+      {"SmokeShellGreen", 4},
+      {"ace_microdagr",1}
+    };
+  };
+  class PL: SL {};
+  class ZEUS: SL {};
+  class TL: SL {
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"acre_prc148",1},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"ace_ir_strobe_item",1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 4},
+      {"SmokeShellGreen", 4},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class DFO: SL {
+    assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio","B_UavTerminal"};
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "binocular"
+      };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"acre_prc148",2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"ace_microdagr",1},
+      {"ITC_Land_B_AR2i_Packed",2},
+      {"ACE_UAVBattery",2}
+    };
+  };
+
+  class FSO: DFO {};
+  class FO: DFO {
+    assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "Laserdesignator_03"
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"acre_prc148",1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"laserbatteries",2},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class RTO: baseUnit {
+    backpack[]={"crab_radiobag_01_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"ACRE_PRC117F",1}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_srifle_svd",
+        {"rhs_10Rnd_762x54mmR_7N14","rhs_acc_pso1m2","cup_svd_camo_g"}
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_10Rnd_762x54mmR_7N14",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"CUP_muzzle_snds_KZRZP_SVD",1},
+      {"rhs_10Rnd_762x54mmR_7N14",6},
+	  {"ACE_10Rnd_762x54_Tracer_mag",4},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+  class DMR: DM {};
+
+  class MGL: baseUnit {
+
+    weapons[] = {
+      {"CUP_glaunch_6G30",
+        {"CUP_6Rnd_HE_GP25_M"}
+      },
+        {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"CUP_6Rnd_HE_GP25_M",2},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"CUP_6Rnd_HE_GP25_M",4},
+      {"16rnd_9x21_mag",4},
+      {"handgrenade",2},
+      {"SmokeShell",2}
+    };
+  };
+
+  class GN: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM_gl",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_vog25"}
+        },
+        {"CUP_arifle_AKMS_gl",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_vog25"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        }
+      };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",8},
+      {"handgrenade", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"handgrenade",2},
+      {"rhs_vog25",12},
+      {"rhs_vog25p",8},
+	  {"rhs_vg40tb",4},
+      {"1_rnd_smoke_grenade_shell", 4}
+    };
+  };
+  class UGL: GN {};
+
+  class MAT: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKMS",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      {"rhs_weap_rpg7",
+        {"rhs_rpg7_pg7v_mag"}
+      }
+    };
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7v_mag", 1},
+      {"rhs_rpg7_og7v_mag", 2}
+    };
+  };
+
+  class MATA: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7v_mag", 2},
+      {"rhs_rpg7_og7v_mag", 2}
+    };
+  };
+
+  class HAT: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKMS",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      {"rhs_weap_rpg7",
+        {"rhs_rpg7_og7v_mag"}
+      }
+    };
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7vr_mag", 2},
+      {"rhs_rpg7_og7v_mag", 1}
+    };
+  };
+
+  class HATA: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7vr_mag", 2},
+	  {"rhs_rpg7_og7v_mag",1},
+      {"rhs_rpg7_tbg7v_mag", 1}
+    };
+  };
+
+  class ME: baseUnit {
+    ace_medic = 2;
+    vest[] = {"V_HarnessO_ghex_F"};
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"ACE_fieldDressing",15},
+      {"ACE_packingBandage",10},
+      {"ACE_quikclot",15},
+      {"ACE_elasticBandage",15},
+      {"ACE_morphine",8},
+      {"ACE_epinephrine",8},
+      {"ACE_adenosine",8},
+      {"ACE_salineIV_250",4},
+      {"ACE_salineiv_500",4},
+      {"ACE_salineiv",2},
+      {"ACE_bloodIV",4},
+      {"ACE_personalAidKit",1},
+      {"ACE_surgicalKit",1},
+      {"ACE_splint",8},
+      {"ACE_tourniquet",5}
+    };
+  };
+  class MED: ME {};
+
+  class RM: baseUnit {
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"handgrenade",4},
+      {"SmokeShell",2},
+	  {"rhs_75Rnd_762x39mm_89",1},	  
+      {"150rnd_762x54_box",1},      
+      {"ACE_salineIV_500",1}
+    };
+  };
+  class RF: RM {};
+
+  class GPMG: baseUnit {
+    weapons[] = {
+      {"CUP_lmg_PKMN",
+        {"150rnd_762x54_box","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"150rnd_762x54_box",1},
+      {"16rnd_9x21_mag",3},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+	  {"CUP_muzzle_snds_KZRZP_PK",1},
+      {"150rnd_762x54_box",3},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+  class MG: GPMG {};
+
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_rpk74",
+        {"rhs_75Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"rhs_75Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_75Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
+
+  class GPMGA: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKM",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "binocular"
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89",4},
+      {"rhs_30Rnd_762x39mm_tracer",2},
+      {"SmokeShell",2},
+      {"handgrenade",2},
+      {"150rnd_762x54_box",2},	  
+      {"150rnd_762x54_box_tracer",2}
+    };
+  };
+
+  class PT: baseUnit {
+
+    weapons[] = {
+      {"CUP_smg_Bizon",
+        {"CUP_64Rnd_9x19_Bizon_M","ace_acc_pointer_green"}
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      }
+    };
+
+    headgear[] = {
+      "rhsusf_hgu56p_visor_white",
+      "rhsusf_hgu56p_black",
+      "rhsusf_hgu56p_visor_mask_pink"
+      };
+
+    goggles[] = {rhs_balaclava1_olive};
+
+    vest[] = {"v_tacChestrig_oli_f"};
+    vestContents[] = {
+      {"acre_prc148",1},
+      {"CUP_64Rnd_9x19_Bizon_M",3},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[] = {"b_fieldpack_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"SmokeShell",2},
+      {"CUP_64Rnd_9x19_Bizon_M",3},
+      {"16rnd_9x21_mag",2},	  
+      {"SmokeShellgreen",2},
+      {"handgrenade",2},
+      {"Chemlight_green",2},
+      {"ace_ir_strobe_item",1},
+      {"Toolkit",1},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class PILOT: PT {};
+
+  class LauncherCrate {
+    vehCargoWeapons[] = {
+      {"rhs_weap_rpg26",10},
+	  {"rhs_weap_rshg2",4},
+      {"rhs_weap_rpg7",2},
+      {"ACE_Vector",2}
+    };
+    vehCargoMagazines[] = {
+      {"rhs_rpg7_og7v_mag",6},
+      {"rhs_rpg7_pg7v_mag",6},
+	  {"rhs_rpg7_tbg7v_mag",6},
+      {"rhs_rpg7_pg7vr_mag",6}
+    };
+    vehCargoRucks[] = {
+      {"b_carryall_ghex_f",2}
+    };
+  };
+  class LargeGearCrate {
+    vehCargoWeapons[] = {
+      {"rhs_weap_rpg26",6},
+      {"ACE_Vector",2}
+    };
+    vehCargoMagazines[] = {
+      {"rhs_30Rnd_762x39mm_89",40},
+      {"rhs_30Rnd_762x39mm_tracer",10},
+      {"rhs_75Rnd_762x39mm_89",20},
+      {"rhs_10Rnd_762x54mmR_7N14",10},
+      {"150rnd_762x54_box",8},
+      {"150rnd_762x54_box_tracer",2},
+      {"handgrenade",20},
+      {"SmokeShell",10},
+      {"rhs_vog25",15},
+	  {"rhs_vog25p",15},
+	  {"rhs_vg40tb",10},
+      {"DemoCharge_Remote_Mag",8}
+    };
+    vehCargoItems[] = {
+      {"ToolKit",1},
+      {"ACE_M26_Clacker",4},
+      {"ACE_DefusalKit",2},
+      {"ACE_fieldDressing",20},
+      {"ACE_packingBandage",20},
+      {"ACE_quikclot",20},
+      {"ACE_Tourniquet",8},
+      {"ACE_splint",4},
+      {"ACE_morphine",4},
+      {"ACE_epinephrine",4},
+      {"ACE_adenosine",4},
+      {"ACE_salineIV",4},      
+      {"ACE_salineIV_500",4},
+      {"ACE_Flashlight_MX991",4},
+      {"ACE_MapTools",4}
+    };
+    vehCargoRucks[] = {
+      {"b_carryall_ghex_f",4}
+    };
+  };
+};

--- a/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_rus.hpp
+++ b/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_rus.hpp
@@ -1,4 +1,4 @@
-  class CDF_des {
+  class CDF_rus {
     class BaseUnit {
       ace_earplugs = 1;
       allowPlayerGoggles = 0;
@@ -6,28 +6,35 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         }
       };
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhs_booniehat2_marpatd"};
+      headgear[] = {
+        "H_HelmetAggressor_cover_F",
+        "H_HelmetAggressor_F"
+      };
 
       goggles[] = {
+        "rhsusf_shemagh_gogg_grn",
+        "rhsusf_shemagh2_gogg_grn",
+        "rhsusf_shemagh_gogg_od",
+        "rhsusf_shemagh2_gogg_od",
         "rhsusf_shemagh_gogg_tan",		
         "rhsusf_shemagh2_gogg_tan"
       };
 
-      uniform[] = {"rhs_uniform_emr_des_patchless"};
+      uniform[] = {"U_O_R_Gorka_01_F"};
       uniformContents[] = {
         {"ACE_fieldDressing",4},
         {"ACE_elasticBandage",4},
@@ -40,9 +47,9 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {v_tacchestrig_grn_f};
+      vest[] = {V_CarrierRigKBT_01_light_Olive_F};
       vestContents[] = {
-        {"CUP_20Rnd_762x51_B_SCAR",6},
+        {"rhs_30Rnd_545x39_7N22_AK",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
@@ -52,8 +59,8 @@
       backpack[] = {"b_kitbag_rgr"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsgref_sdn6_silencer", 1},
-        {"CUP_20Rnd_762x51_B_SCAR",4},
+        {"rhs_acc_dtk4short", 1},
+        {"rhs_30Rnd_545x39_7N22_AK",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,21 +70,21 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","rhsusf_acc_su230","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","rhsusf_acc_su230","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +94,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,21 +109,21 @@
   class TL: SL {
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +132,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,22 +148,22 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -168,8 +175,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -185,22 +192,22 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -212,9 +219,9 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -227,9 +234,9 @@
     backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -238,18 +245,18 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"cup_arifle_mk20",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
+      {"srifle_DMR_05_blk_F",
+        {"10Rnd_93x64_DMR_05_Mag","ace_acc_pointer_green","optic_ams","rhs_acc_harris_swivel"}
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"10Rnd_93x64_DMR_05_Mag",5},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -259,9 +266,8 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"optic_tws_mg",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_93mmg",1},
+      {"10Rnd_93x64_DMR_05_Mag",5},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -272,19 +278,18 @@
   class MGL: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m32",
-        {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
+      {"CUP_glaunch_6G30",
+        {"CUP_6Rnd_HE_GP25_M"}
       },
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"rhsusf_mag_6rnd_m433_hedp",2},
-      {"rhsusf_mag_6rnd_m441_he",1},
+      {"CUP_6Rnd_HE_GP25_M",2},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -294,9 +299,7 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_mag_6rnd_m433_hedp",2},
-      {"rhsusf_mag_6rnd_m441_he",1},
-      {"rhsusf_mag_6rnd_m714_white",2},
+      {"CUP_6Rnd_HE_GP25_M",4},
       {"16rnd_9x21_mag",4},
       {"handgrenade",2},
       {"SmokeShell",2}
@@ -307,21 +310,21 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_cqc_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_AK107_GL_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_vog25","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_AK74M_GL_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_vog25","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         }
       };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -329,13 +332,14 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"cup_1rnd_hedp_m203",12},
-      {"cup_1rnd_he_m203",12},
-      {"rhs_mag_m714_white", 4}
+      {"rhs_vog25",12},
+      {"rhs_vog25p",8},
+      {"rhs_vg25tb",4},
+      {"rhs_vg40md", 4}
     };
   };
   class UGL: GN {};
@@ -343,23 +347,23 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_AK105_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
-      {"launch_MRAWS_green_rail_F",
-        {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
+      {"launch_RPG32_green_F",
+        {"RPG32_F", "ace_acc_pointer_green"}
       }
     };
     backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
-      {"MRAWS_HEAT55_F", 1},
-      {"MRAWS_HE_F", 2}
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
+      {"RPG32_F", 1},
+      {"RPG32_HE_F", 2}
     };
   };
 
@@ -367,14 +371,14 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
@@ -383,30 +387,30 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
-      {"MRAWS_HEAT55_F", 2},
-      {"MRAWS_HE_F", 2}
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
+      {"RPG32_F", 2},
+      {"RPG32_HE_F", 2}
     };
   };
 
   class HAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_AK105_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
-      {"launch_o_titan_short_f",
+      {"launch_I_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
       {"Titan_AT", 1}
     };
   };
@@ -415,14 +419,14 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_mx2a"
@@ -431,8 +435,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -440,12 +444,12 @@
 
   class ME: baseUnit {
     ace_medic = 2;
-    vest[] = {"V_SmershVest_01_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -468,11 +472,11 @@
   class RM: baseUnit {
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 4},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"150rnd_762x51_box",1},
+      {"150rnd_762x54_box",1},      
       {"ACE_salineIV_500",1}
     };
   };
@@ -480,17 +484,17 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"cup_lmg_mk48_nohg_tan",
-        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
+      {"CUP_lmg_Pecheneg",
+        {"150rnd_762x54_box","ace_acc_pointer_green","rhs_acc_ekp8_02d"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
       }
     };
-    vest[] = {"V_SmershVest_01_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"150rnd_762x51_box",1},
+      {"150rnd_762x54_box",1},
       {"16rnd_9x21_mag",3},
       {"ace_maptools",1}
     };
@@ -498,23 +502,47 @@
     backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_h_mg_blk_f",1},
-      {"150rnd_762x51_box",4},
+      {"CUP_muzzle_snds_KZRZP_PK",1},
+      {"150rnd_762x54_box",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class LMG: GPMG {};
+  class MG: GPMG {};
 
-  class MG: GPMG {}; 
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_RPK74M_railed",
+        {"CUP_60Rnd_545x39_AK74M_M","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"CUP_60Rnd_545x39_AK74M_M",4},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"rhs_acc_dtk4short",1},
+      {"CUP_60Rnd_545x39_AK74M_M",8},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
+      {"CUP_arifle_AK107_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "binocular"
@@ -523,23 +551,23 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",2},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK",4},
+      {"rhs_30Rnd_545x39_AK_green",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"150rnd_762x51_box",2},	  
-      {"150rnd_762x51_box_tracer",2}
+      {"150rnd_762x54_box",2},	  
+      {"150rnd_762x54_box_tracer",1}
     };
   };
 
   class PT: baseUnit {
 
     weapons[] = {
-      {"cup_smg_mac10_rail",
-        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      {"CUP_arifle_AKS74U_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"}
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       }
     };
@@ -555,7 +583,7 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhs_30Rnd_545x39_7N22_AK",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
@@ -564,7 +592,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhs_30Rnd_545x39_7N22_AK",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -598,12 +626,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",60},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
-      {"150rnd_762x51_box",20},
+      {"rhs_30Rnd_545x39_7N22_AK",40},
+      {"rhs_30Rnd_545x39_AK_green",10},
+      {"CUP_60Rnd_545x39_AK74M_M",20},
+      {"10Rnd_93x64_DMR_05_Mag",10},
+      {"150rnd_762x54_box",8},
+      {"150rnd_762x54_box_tracer",2},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"cup_1rnd_hedp_m203",20},
+      {"rhs_vog25",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}

--- a/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_wdl.hpp
+++ b/CO18_CZ_Livonia_V29.Enoch/tb3/murk/cdf_wdl.hpp
@@ -4,11 +4,16 @@
       allowPlayerGoggles = 0;
       ace_medic = 1;
 
-      weapons[] = {
-        {"rhs_weap_m16a4_imod_grip",
-          {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"}
+    weapons[] = {
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
         },
-        {"hgun_p07_khk_f",
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
@@ -47,7 +52,7 @@
 
       vest[] = {V_SmershVest_01_F};
       vestContents[] = {
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+        {"CUP_30Rnd_556x45_Emag",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
@@ -58,7 +63,7 @@
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
         {"rhsusf_acc_rotex5_grey", 1},
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+        {"CUP_30Rnd_556x45_Emag",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -67,17 +72,22 @@
   class SL: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "rhsusf_acc_su230","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -89,7 +99,7 @@
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -101,17 +111,22 @@
   class ZEUS: SL {};
   class TL: SL {
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -123,7 +138,7 @@
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -135,18 +150,23 @@
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio","B_UavTerminal"};
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -155,11 +175,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -168,15 +188,21 @@
       {"ACE_UAVBattery",2}
     };
   };
+
   class FSO: DFO {};
   class FO: DFO {
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
@@ -184,7 +210,7 @@
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -193,12 +219,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -208,32 +234,31 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
   };
 
-  class DM: baseUnit {
+  class HRF: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_sr25_ec",
-        {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a","rhsusf_acc_harris_bipod"}
+      {"CUP_arifle_Mk17_CQC_SFG_woodland",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_tws_mg"}
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
     };
 
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",6},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -242,9 +267,43 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
       {"rhsgref_sdn6_silencer",1},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",4},
-      {"rhsusf_20Rnd_762x51_sr25_M62_Mag",2},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_arifle_mk20_woodland",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_ams_khk","bipod_02_f_lush"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_vector"
+    };
+
+    vest[] = {"V_SmershVest_01_radio_F"};
+    vestContents[] = {
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -258,7 +317,7 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_khk_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
@@ -274,7 +333,7 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_mag_6rnd_m433_hedp",2},
@@ -289,17 +348,22 @@
   class GN: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_M203",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      }
-    };
+      {
+        {"CUP_arifle_Mk16_STD_EGLM_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag","cup_1rnd_hedp_m203"}
+        },
+        {"CUP_arifle_Mk16_CQC_EGLM_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag","cup_1rnd_hedp_m203"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        }
+      };
 
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",8},
+      {"CUP_30Rnd_556x45_Emag",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -308,11 +372,11 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhs_mag_m433_hedp",12},
-      {"rhs_mag_m441_he",12},
+      {"cup_1rnd_hedp_m203",12},
+      {"cup_1rnd_he_m203",12},
       {"rhs_mag_m714_white", 4}
     };
   };
@@ -321,10 +385,10 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
+      {"CUP_arifle_Mk16_CQC_FG_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
@@ -335,7 +399,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -344,20 +408,25 @@
   class MATA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -366,10 +435,10 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
+      {"CUP_arifle_Mk16_CQC_FG_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
@@ -379,7 +448,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"Titan_AT", 1}
     };
   };
@@ -387,20 +456,25 @@
   class HATA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
+      "ace_mx2a"
     };
     
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -409,11 +483,11 @@
   class ME: baseUnit {
     ace_medic = 2;
     vest[] = {"V_SmershVest_01_F"};
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -437,10 +511,10 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 6},
+      {"CUP_30Rnd_556x45_Emag", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote",1},
+      {"150Rnd_556x45_Drum_Green_Mag_f",1},
       {"ACE_salineIV_500",1}
     };
   };
@@ -448,25 +522,26 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_m60e4",
+        {"rhsusf_100Rnd_762x51_m61_ap","ace_acc_pointer_green","Optic_ERCO_blk_f"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"o_nvgoggles_grn_f",1},
+      {"rhsusf_100Rnd_762x51_m61_ap",3},
       {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
     backpack[]={"b_kitbag_sgg"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"rhsusf_100Rnd_762x51_m61_ap",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
@@ -476,15 +551,15 @@
   class LMG: baseUnit {
  
     weapons[] = {
-      {"rhs_weap_m249_light_S_vfg2",
-        {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote","rhsusf_acc_anpeq15side_bk","optic_Holosight_blk_F","rhsusf_acc_grip4_bipod"},
+      {"CUP_arifle_Mk16_SV_woodland",
+        {"150Rnd_556x45_Drum_Green_Mag_F","ace_acc_pointer_green","optic_Holosight_khk_F","bipod_02_F_lush"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vestContents[] = {
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",2},
+      {"150Rnd_556x45_Drum_Green_Mag_F",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
       {"handgrenade",2},
@@ -492,8 +567,9 @@
     };
 
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",4},
+      {"150Rnd_556x45_Drum_Green_Mag_F",6},
       {"SmokeShell",2},
       {"handgrenade",2}
     };   
@@ -502,23 +578,24 @@
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F"},
+      {"CUP_arifle_Mk16_SV_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F","bipod_02_F_lush"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
+      {"rhsusf_100Rnd_762x51_m61_ap",4},	  
       {"rhsusf_100Rnd_762x51_m62_tracer",2}
     };
   };
@@ -526,11 +603,11 @@
   class PT: baseUnit {
 
     weapons[] = {
-      {"smg_03c_tr_black",
-        {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
+      {"cup_smg_mac10_rail",
+        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
       },
-      {"hgun_p07_khk_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       }
     };
 
@@ -545,15 +622,16 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"50rnd_570x28_smg_03",2},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
-    backpack[] = {"b_tacticalpack_oli"};
+    backpack[] = {"b_fieldpack_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"50rnd_570x28_smg_03",4},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -563,7 +641,9 @@
       {"ace_microdagr",1}
     };
   };
+
   class PILOT: PT {};
+
   class LauncherCrate {
     vehCargoWeapons[] = {
       {"rhs_weap_m72a7",10},
@@ -576,7 +656,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_fieldpack_green_f",2}
+      {"b_carryall_green_f",2}
     };
   };
   class LargeGearCrate {
@@ -585,15 +665,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",40},
+      {"CUP_30Rnd_556x45_Emag",40},
       {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",10},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",10},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",10},
-      {"rhsusf_20Rnd_762x51_SR25_m62_Mag",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
+      {"150Rnd_556x45_Drum_Green_Mag_F",10},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",10},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",4},
+      {"rhsusf_100Rnd_762x51_m61_ap",8},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"rhs_mag_m433_hedp",20},
+      {"cup_1rnd_hedp_m203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -616,7 +696,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_carryall_oli",4}
+      {"b_carryall_green_f",4}
     };
   };
 };

--- a/CO18_CZ_Livonia_V29.Enoch/tb3/murk/loadouts.hpp
+++ b/CO18_CZ_Livonia_V29.Enoch/tb3/murk/loadouts.hpp
@@ -1,3 +1,6 @@
 #include "cdf_blk.hpp"
 #include "cdf_des.hpp"
 #include "cdf_wdl.hpp"
+#include "cdf_rus.hpp"
+#include "cdf_liz.hpp"
+#include "cdf_jng.hpp"

--- a/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_blk.hpp
+++ b/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_blk.hpp
@@ -8,7 +8,7 @@
         {"arifle_msbs65_black_f",
           {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"}
         },
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
@@ -61,7 +61,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_erco_blk_f",},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -95,7 +95,7 @@
       {"arifle_msbs65_ubs_black_f",
         {"30rnd_65x39_caseless_msbs_mag","6rnd_12gauge_pellets","ace_acc_pointer_green", "optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -131,7 +131,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -152,10 +152,10 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
-      {"30rnd_65x39_caseless_msbs_mag",6},
+      {"30rnd_65x39_caseless_msbs_mag",4},
       {"SmokeShell",2},
-      {"SmokeshellRed", 2},
-      {"SmokeShellGreen", 2},
+      {"SmokeshellRed", 1},
+      {"SmokeShellGreen", 1},
       {"ace_microdagr",1},
       {"ITC_Land_B_AR2i_Packed",2},
       {"ACE_UAVBattery",2}
@@ -169,7 +169,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_Holosight_blk_F",},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
@@ -201,7 +201,7 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"crab_radiobag_01_black_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
@@ -212,21 +212,20 @@
     };
   };
 
-  class DM: baseUnit {
+  class HRF: baseUnit {
 
     weapons[] = {
-      {"srifle_dmr_03_f",
-        {"ace_20rnd_762x51_mk319_mod_0_mag","ace_acc_pointer_green","rhsusf_acc_su230a","rhs_acc_harris_swivel"}
+      {"CUP_arifle_Mk17_CQC_SFG_black",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_tws_mg"}
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
     };
 
-    vest[] = {"V_platecarrier2_blk"};
+    vest[] = {"V_platecarrier1_blk"};
     vestContents[] = {
-      {"ace_20rnd_762x51_mk319_mod_0_mag",6},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -235,9 +234,43 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_b",1},
-      {"ace_20rnd_762x51_mk319_mod_0_mag",4},
-      {"ace_20rnd_762x51_mag_tracer",2},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_arifle_mk20_black",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_ams","bipod_02_f_blk"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_vector"
+    };
+
+    vest[] = {"V_platecarrier1_blk"};
+    vestContents[] = {
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -251,7 +284,7 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
@@ -279,13 +312,44 @@
     };
   };
 
+  class SMG: baseUnit {
+
+    weapons[] = {
+      {"rhsusf_weap_mp7a2",
+        {"rhsusf_mag_40rnd_46x30_jhp","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      }
+    };
+
+    vest[] = {"V_platecarrier1_blk"};
+    vestContents[] = {
+      {"rhsusf_mag_40rnd_46x30_jhp",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_viperlightharness_blk_f"};
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"rhsusf_mag_40rnd_46x30_jhp",6},
+      {"ace_cts9",2},
+      {"ace_m84",2},
+      {"16rnd_9x21_mag",4},
+      {"handgrenade",4}
+    };
+  };
+
   class GN: baseUnit {
 
     weapons[] = {
       {"arifle_msbs65_gl_black_f",
         {"30rnd_65x39_caseless_msbs_mag", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F", "rhsusf_acc_grip1"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       }
     };
@@ -317,13 +381,15 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
+    vest[] = {"V_tacvestir_blk"};
+
     backpack[]={"b_viperlightharness_blk_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
@@ -340,7 +406,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -362,13 +428,15 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
+    vest[] = {"V_tacvestir_blk"};
+
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f",1},
@@ -383,7 +451,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -406,7 +474,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
-      {"30rnd_65x39_caseless_msbs_mag",6},
+      {"30rnd_65x39_caseless_msbs_mag",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -441,25 +509,25 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_mk48_nohg",
+        {"150rnd_762x51_box","rhsusf_acc_anpeq15side_bk","Optic_ERCO_blk_f"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vest[] = {"V_tacvestir_blk"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
-      {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
+      {"150rnd_762x51_box",2},
+      {"16rnd_9x21_mag",1},
       {"ace_maptools",1}
     };
 
     backpack[]={"b_viperlightharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_black_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"150rnd_762x51_box",4},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
@@ -472,7 +540,7 @@
       {"lmg_mk200_black_f",
         {"200rnd_65x39_cased_box","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_harris_swivel"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
@@ -480,11 +548,11 @@
     vestContents[] = {
       {"200rnd_65x39_cased_box",2},
       {"16rnd_9x21_mag",2},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
       {"200rnd_65x39_cased_box",4},
       {"SmokeShell",2},
@@ -498,7 +566,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
@@ -506,13 +574,14 @@
 
     backpack[]={"b_viperharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f",1},
       {"30rnd_65x39_caseless_msbs_mag",4},
       {"30rnd_65x39_caseless_msbs_mag_tracer",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
-      {"rhsusf_100Rnd_762x51_m62_tracer",2}
+      {"150rnd_762x51_box",2},	  
+      {"150rnd_762x51_box_tracer",2}
     };
   };
 
@@ -522,7 +591,7 @@
       {"smg_03c_tr_black",
         {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
@@ -543,6 +612,7 @@
 
     backpack[] = {"b_viperharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
       {"50rnd_570x28_smg_03",4},
       {"16rnd_9x21_mag",2},	  
@@ -581,8 +651,8 @@
       {"200rnd_65x39_cased_box",10},
       {"ace_20rnd_762x51_mk319_mod_0_mag",10},
       {"ace_20rnd_762x51_mag_tracer",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
-      {"rhsusf_100Rnd_762x51_m62_tracer",4},
+      {"150rnd_762x51_box",8},
+      {"150rnd_762x51_box_tracer",4},
       {"handgrenade",20},
       {"SmokeShell",10},
       {"rhs_mag_m433_hedp",20},

--- a/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_des.hpp
+++ b/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_des.hpp
@@ -6,21 +6,21 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhsusf_protech_helmet_rhino"};
+      headgear[] = {"rhs_booniehat2_marpatd"};
 
       goggles[] = {
         "rhsusf_shemagh_gogg_tan",		
@@ -40,20 +40,20 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {V_platecarrier1_blk};
+      vest[] = {v_tacchestrig_grn_f};
       vestContents[] = {
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+        {"CUP_20Rnd_762x51_B_SCAR",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
         {"ace_maptools",1}
       };
 
-      backpack[] = {"b_viperlightharness_blk_f"};
+      backpack[] = {"b_kitbag_rgr"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsusf_acc_rotex5_grey", 1},
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+        {"rhsgref_sdn6_silencer", 1},
+        {"CUP_20Rnd_762x51_B_SCAR",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,21 +63,21 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +87,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,21 +102,21 @@
   class TL: SL {
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
-    vest[] = {"V_platecarrier1_blk"};
+        },
+        "ace_vector"
+      };
+    vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +125,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,22 +141,22 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
-    vest[] = {"V_platecarrier1_blk"};
+        },
+        "ace_vector"
+      };
+    vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -165,11 +165,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -178,28 +178,29 @@
       {"ACE_UAVBattery",2}
     };
   };
+
   class FSO: DFO {};
   class FO: DFO {
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
     weapons[] = {
       {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+        {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
     };
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -208,12 +209,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -223,12 +224,12 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -237,18 +238,18 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_sr25_ec_d",
-        {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a","rhsusf_acc_harris_bipod"}
+      {"cup_arifle_mk20",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -257,9 +258,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
       {"rhsgref_sdn6_silencer",1},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",4},
-      {"rhsusf_20Rnd_762x51_sr25_M62_Mag",2},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -273,13 +275,13 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
     };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
       {"rhsusf_mag_6rnd_m433_hedp",2},
       {"rhsusf_mag_6rnd_m441_he",1},
@@ -289,7 +291,7 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_mag_6rnd_m433_hedp",2},
@@ -304,17 +306,22 @@
   class GN: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m4a1_M203s_d",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F"},
-      },
-      {"hgun_p07_f",
-        {"16rnd_9x21_mag"}
-      }
-    };
+      {
+        {"CUP_arifle_Mk17_cqc_EGLM",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        },
+        {"CUP_arifle_Mk17_STD_EGLM",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        }
+      };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",8},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -322,12 +329,12 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhs_mag_m433_hedp",12},
-      {"rhs_mag_m441_he",12},
+      {"cup_1rnd_hedp_m203",12},
+      {"cup_1rnd_he_m203",12},
       {"rhs_mag_m714_white", 4}
     };
   };
@@ -336,26 +343,21 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        }
-      },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
-    backpack[]={"b_viperlightharness_blk_f"};
+    backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -365,24 +367,24 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+        },
+        "ace_vector"
+      };
     
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -391,16 +393,11 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        }
-      },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
@@ -408,8 +405,8 @@
     };
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"Titan_AT", 1}
     };
   };
@@ -418,24 +415,24 @@
 
     weapons[] = {
       {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+        {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
-      "ace_vector"
+      "ace_mx2a"
     };
     
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -443,12 +440,12 @@
 
   class ME: baseUnit {
     ace_medic = 2;
-    vest[] = {"V_tacvestir_blk"};
-    backpack[]={"b_viperharness_blk_f"};
+    vest[] = {"V_SmershVest_01_F"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -471,11 +468,11 @@
   class RM: baseUnit {
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 6},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 4},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote",1},
+      {"150rnd_762x51_box",1},
       {"ACE_salineIV_500",1}
     };
   };
@@ -483,89 +480,67 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_mk48_nohg_tan",
+        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
-    vest[] = {"V_tacvestir_blk"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"o_nvgoggles_grn_f",1},
+      {"150rnd_762x51_box",1},
       {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperlightharness_blk_f"};
+    backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"150rnd_762x51_box",4},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class MG: GPMG {};
+  class LMG: GPMG {};
 
-  class LMG: baseUnit {
- 
-    weapons[] = {
-      {"rhs_weap_m249_light_S_vfg2",
-        {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote","rhsusf_acc_anpeq15side_bk","optic_Holosight_blk_F","rhsusf_acc_grip4_bipod"},
-      },
-      {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
-      }
-    };
-    vestContents[] = {
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",2},
-      {"SmokeShell",2},
-      {"16rnd_9x21_mag",2},
-      {"handgrenade",2},
-      {"ace_maptools",1}
-    };
-
-    backpackContents[] = {
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",4},
-      {"SmokeShell",2},
-      {"handgrenade",2}
-    };   
-  };
+  class MG: GPMG {}; 
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F"},
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
-      {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",2},
+      {"o_nvgoggles_grn_f",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR",2},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
-      {"rhsusf_100Rnd_762x51_m62_tracer",2}
+      {"150rnd_762x51_box",2},	  
+      {"150rnd_762x51_box_tracer",2}
     };
   };
 
   class PT: baseUnit {
 
     weapons[] = {
-      {"smg_03c_tr_black",
-        {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
+      {"cup_smg_mac10_rail",
+        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
       },
-      {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       }
     };
 
@@ -580,15 +555,16 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"50rnd_570x28_smg_03",2},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
-    backpack[] = {"b_tacticalpack_oli"};
+    backpack[] = {"b_fieldpack_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"50rnd_570x28_smg_03",4},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -598,7 +574,9 @@
       {"ace_microdagr",1}
     };
   };
+
   class PILOT: PT {};
+
   class LauncherCrate {
     vehCargoWeapons[] = {
       {"rhs_weap_m72a7",10},
@@ -611,7 +589,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_fieldpack_green_f",2}
+      {"b_carryall_green_f",2}
     };
   };
   class LargeGearCrate {
@@ -620,15 +598,12 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",40},
-      {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",10},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",10},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",10},
-      {"rhsusf_20Rnd_762x51_SR25_m62_Mag",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
+      {"CUP_20Rnd_762x51_B_SCAR",60},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
+      {"150rnd_762x51_box",20},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"rhs_mag_m433_hedp",20},
+      {"cup_1rnd_hedp_m203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -651,7 +626,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_viperharness_blk_f",4}
+      {"b_carryall_green_f",4}
     };
   };
 };

--- a/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_jng.hpp
+++ b/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_jng.hpp
@@ -1,4 +1,4 @@
-  class CDF_des {
+  class CDF_jng {
     class BaseUnit {
       ace_earplugs = 1;
       allowPlayerGoggles = 0;
@@ -6,11 +6,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -20,14 +20,31 @@
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhs_booniehat2_marpatd"};
-
-      goggles[] = {
-        "rhsusf_shemagh_gogg_tan",		
-        "rhsusf_shemagh2_gogg_tan"
+      headgear[] = {
+        "h_bandanna_khk_hs",
+		"rhsusf_bowman_cap",
+		"h_cap_headphones",
+		"h_cap_oli_hs",
+        "H_Booniehat_tna_F",
+        "H_MilCap_tna_F"
       };
 
-      uniform[] = {"rhs_uniform_emr_des_patchless"};
+      goggles[] = {
+		"g_bandanna_oli",
+		"rhs_googles_clear",
+        "rhsusf_shemagh_grn",
+        "rhsusf_shemagh2_grn",
+        "rhsusf_shemagh_od",
+        "rhsusf_shemagh2_od",
+        "rhsusf_shemagh_tan",		
+        "rhsusf_shemagh2_tan"
+      };
+
+      uniform[] = {
+        "U_B_T_Soldier_F",
+        "U_B_T_Soldier_AR_F",
+        "U_B_T_Soldier_SL_F"
+      };
       uniformContents[] = {
         {"ACE_fieldDressing",4},
         {"ACE_elasticBandage",4},
@@ -40,20 +57,20 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {v_tacchestrig_grn_f};
+      vest[] = {V_SmershVest_01_F};
       vestContents[] = {
-        {"CUP_20Rnd_762x51_B_SCAR",6},
+        {"rhsgref_30rnd_556x45_vhs2",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
         {"ace_maptools",1}
       };
 
-      backpack[] = {"b_kitbag_rgr"};
+      backpack[] = {"b_carryall_green_f"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsgref_sdn6_silencer", 1},
-        {"CUP_20Rnd_762x51_B_SCAR",4},
+        {"muzzle_snds_m_khk_F", 1},
+        {"rhsgref_30rnd_556x45_vhs2",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,11 +80,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -75,9 +92,9 @@
       },
       "ace_vector"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +104,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,11 +119,11 @@
   class TL: SL {
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -114,9 +131,9 @@
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +142,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,11 +158,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -153,10 +170,10 @@
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -165,11 +182,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -185,11 +202,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -197,10 +214,10 @@
       },
       "Laserdesignator_03"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -209,12 +226,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -224,12 +241,12 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"crab_radiobag_01_wdl_f"};
+    backpack[]={"crab_radiobag_01_tropic_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -238,8 +255,8 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"cup_arifle_mk20",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
+      {"srifle_DMR_03_khaki_F",
+        {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag","ace_acc_pointer_green","optic_ams_khk","rhs_acc_harris_swivel"}
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -247,9 +264,9 @@
       "ace_vector"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -259,9 +276,9 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"optic_tws_mg",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_B",1},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",4},
+	  {"ACE_20Rnd_762x51_Mag_Tracer",4},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -281,7 +298,7 @@
       "ace_yardage450"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"rhsusf_mag_6rnd_m433_hedp",2},
       {"rhsusf_mag_6rnd_m441_he",1},
@@ -307,11 +324,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_cqc_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_G36A_AG36_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","rhsgref_30rnd_556x45_vhs2","CUP_1Rnd_HE_M203"}
         },
-        {"CUP_arifle_Mk17_STD_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_G36K_RIS_AG36_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","rhsgref_30rnd_556x45_vhs2","CUP_1Rnd_HE_M203"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -319,23 +336,24 @@
         }
       };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"cup_1rnd_hedp_m203",12},
-      {"cup_1rnd_he_m203",12},
-      {"rhs_mag_m714_white", 4}
+      {"CUP_1Rnd_HE_M203",12},
+      {"CUP_1Rnd_HEDP_M203",12},
+      {"1_rnd_smoke_grenade_shell", 4}
     };
   };
   class UGL: GN {};
@@ -343,8 +361,8 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -353,11 +371,11 @@
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
-    backpack[]={"b_kitbag_rgr"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -367,11 +385,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -380,11 +398,11 @@
         "ace_vector"
       };
     
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -393,8 +411,8 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -403,10 +421,11 @@
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"Titan_AT", 1}
     };
   };
@@ -415,11 +434,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -428,11 +447,11 @@
       "ace_mx2a"
     };
     
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -444,8 +463,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -466,13 +485,15 @@
   class MED: ME {};
 
   class RM: baseUnit {
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 4},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"150rnd_762x51_box",1},
+	  {"CUP_100Rnd_556x45_BetaCMag",1},	  
+      {"150rnd_762x51_box",1},      
       {"ACE_salineIV_500",1}
     };
   };
@@ -480,8 +501,8 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"cup_lmg_mk48_nohg_tan",
-        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
+      {"CUP_lmg_mk48_nohg_od",
+        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_khk_f"},
       },
       {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
@@ -495,24 +516,48 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_kitbag_rgr"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_h_mg_blk_f",1},
-      {"150rnd_762x51_box",4},
+      {"muzzle_snds_m_khk_F",1},
+      {"150rnd_762x51_box",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class LMG: GPMG {};
+  class MG: GPMG {};
 
-  class MG: GPMG {}; 
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_MG36_wdl",
+        {"CUP_100Rnd_556x45_BetaCMag","ace_acc_pointer_green","optic_Holosight_khk_F"},
+      },
+      {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"CUP_100Rnd_556x45_BetaCMag",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"muzzle_snds_m_khk_F",1},
+      {"CUP_100Rnd_556x45_BetaCMag",4},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
+      {"CUP_arifle_MG36_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","Optic_ERCO_khk_f"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -520,12 +565,12 @@
       "binocular"
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",2},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2",4},
+      {"rhsgref_30rnd_556x45_vhs2_t",2},
       {"SmokeShell",2},
       {"handgrenade",2},
       {"150rnd_762x51_box",2},	  
@@ -536,10 +581,10 @@
   class PT: baseUnit {
 
     weapons[] = {
-      {"cup_smg_mac10_rail",
-        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"}
       },
-      {"CUP_hgun_Duty",
+      {"CUP_hgun_duty",
         {"16rnd_9x21_mag"}
       }
     };
@@ -555,7 +600,7 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhsgref_30rnd_556x45_vhs2",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
@@ -564,7 +609,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhsgref_30rnd_556x45_vhs2",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -589,7 +634,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_carryall_green_f",2}
+      {"B_Bergen_tna_F",2}
     };
   };
   class LargeGearCrate {
@@ -598,12 +643,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",60},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
-      {"150rnd_762x51_box",20},
+      {"rhsgref_30rnd_556x45_vhs2",40},
+      {"rhsgref_30rnd_556x45_vhs2_t",10},
+      {"CUP_100Rnd_556x45_BetaCMag",20},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",10},
+      {"150rnd_762x51_box",8},
+      {"150rnd_762x51_box_tracer",2},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"cup_1rnd_hedp_m203",20},
+      {"CUP_1Rnd_HE_M203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -626,7 +674,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_carryall_green_f",4}
+      {"B_Bergen_tna_F",4}
     };
   };
 };

--- a/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_liz.hpp
+++ b/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_liz.hpp
@@ -1,0 +1,680 @@
+  class CDF_liz {
+    class BaseUnit {
+      ace_earplugs = 1;
+      allowPlayerGoggles = 0;
+      ace_medic = 1;
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        }
+      };
+
+      assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
+
+      headgear[] = {
+        "h_bandanna_khk_hs",
+		"rhsusf_bowman_cap",
+		"h_cap_headphones",
+		"h_cap_oli_hs",
+        "H_Booniehat_khk",
+        "H_MilCap_grn"
+      };
+
+      goggles[] = {
+		"g_bandanna_oli",
+		"rhs_googles_clear",
+        "rhsusf_shemagh_grn",
+        "rhsusf_shemagh2_grn",
+        "rhsusf_shemagh_od",
+        "rhsusf_shemagh2_od",
+        "rhsusf_shemagh_tan",		
+        "rhsusf_shemagh2_tan"
+      };
+
+      uniform[] = {
+        "rhsgref_uniform_altis_lizard",
+        "rhsgref_uniform_altis_lizard_olive"
+      };
+      uniformContents[] = {
+        {"ACE_fieldDressing",4},
+        {"ACE_elasticBandage",4},
+        {"ACE_quikclot",4},
+        {"ACE_morphine",2},
+        {"ACE_adenosine",1},
+        {"ACE_tourniquet",2},
+        {"ACE_Splint",2},
+        {"ACE_salineIV_500",1},
+        {"ACE_Flashlight_XL50",1}
+      };
+
+      vest[] = {V_HarnessO_ghex_F};
+      vestContents[] = {
+        {"rhs_30Rnd_762x39mm_89",6},
+        {"handgrenade",2},
+        {"SmokeShell",2},
+        {"16rnd_9x21_mag",2},
+        {"ace_maptools",1}
+      };
+
+      backpack[] = {"b_viperlightharness_ghex_f"};
+      backpackContents[] = {
+        {"CUP_nvg_pvs7",1},
+        {"rhs_acc_pbs1", 1},
+        {"rhs_30Rnd_762x39mm_89",4},
+        {"SmokeShell",2},
+        {"handgrenade",2}
+      };
+    };
+
+  class SL: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_acc_pso1m21"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_acc_pso1m21"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"acre_prc148",1},
+      {"16rnd_9x21_mag",2},
+      {"itc_land_tablet_rover",1},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"ace_ir_strobe_item",1},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 4},
+      {"SmokeShellGreen", 4},
+      {"ace_microdagr",1}
+    };
+  };
+  class PL: SL {};
+  class ZEUS: SL {};
+  class TL: SL {
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"acre_prc148",1},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"ace_ir_strobe_item",1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 4},
+      {"SmokeShellGreen", 4},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class DFO: SL {
+    assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio","B_UavTerminal"};
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "binocular"
+      };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"acre_prc148",2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"ace_microdagr",1},
+      {"ITC_Land_B_AR2i_Packed",2},
+      {"ACE_UAVBattery",2}
+    };
+  };
+
+  class FSO: DFO {};
+  class FO: DFO {
+    assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "Laserdesignator_03"
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"acre_prc148",1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"laserbatteries",2},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class RTO: baseUnit {
+    backpack[]={"crab_radiobag_01_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"ACRE_PRC117F",1}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_srifle_svd",
+        {"rhs_10Rnd_762x54mmR_7N14","rhs_acc_pso1m2","cup_svd_camo_g"}
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_10Rnd_762x54mmR_7N14",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"CUP_muzzle_snds_KZRZP_SVD",1},
+      {"rhs_10Rnd_762x54mmR_7N14",6},
+	  {"ACE_10Rnd_762x54_Tracer_mag",4},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+  class DMR: DM {};
+
+  class MGL: baseUnit {
+
+    weapons[] = {
+      {"CUP_glaunch_6G30",
+        {"CUP_6Rnd_HE_GP25_M"}
+      },
+        {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"CUP_6Rnd_HE_GP25_M",2},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"CUP_6Rnd_HE_GP25_M",4},
+      {"16rnd_9x21_mag",4},
+      {"handgrenade",2},
+      {"SmokeShell",2}
+    };
+  };
+
+  class GN: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM_gl",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_vog25"}
+        },
+        {"CUP_arifle_AKMS_gl",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_vog25"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        }
+      };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",8},
+      {"handgrenade", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"handgrenade",2},
+      {"rhs_vog25",12},
+      {"rhs_vog25p",8},
+	  {"rhs_vg40tb",4},
+      {"1_rnd_smoke_grenade_shell", 4}
+    };
+  };
+  class UGL: GN {};
+
+  class MAT: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKMS",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      {"rhs_weap_rpg7",
+        {"rhs_rpg7_pg7v_mag"}
+      }
+    };
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7v_mag", 1},
+      {"rhs_rpg7_og7v_mag", 2}
+    };
+  };
+
+  class MATA: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7v_mag", 2},
+      {"rhs_rpg7_og7v_mag", 2}
+    };
+  };
+
+  class HAT: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKMS",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      {"rhs_weap_rpg7",
+        {"rhs_rpg7_og7v_mag"}
+      }
+    };
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7vr_mag", 2},
+      {"rhs_rpg7_og7v_mag", 1}
+    };
+  };
+
+  class HATA: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7vr_mag", 2},
+	  {"rhs_rpg7_og7v_mag",1},
+      {"rhs_rpg7_tbg7v_mag", 1}
+    };
+  };
+
+  class ME: baseUnit {
+    ace_medic = 2;
+    vest[] = {"V_HarnessO_ghex_F"};
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"ACE_fieldDressing",15},
+      {"ACE_packingBandage",10},
+      {"ACE_quikclot",15},
+      {"ACE_elasticBandage",15},
+      {"ACE_morphine",8},
+      {"ACE_epinephrine",8},
+      {"ACE_adenosine",8},
+      {"ACE_salineIV_250",4},
+      {"ACE_salineiv_500",4},
+      {"ACE_salineiv",2},
+      {"ACE_bloodIV",4},
+      {"ACE_personalAidKit",1},
+      {"ACE_surgicalKit",1},
+      {"ACE_splint",8},
+      {"ACE_tourniquet",5}
+    };
+  };
+  class MED: ME {};
+
+  class RM: baseUnit {
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"handgrenade",4},
+      {"SmokeShell",2},
+	  {"rhs_75Rnd_762x39mm_89",1},	  
+      {"150rnd_762x54_box",1},      
+      {"ACE_salineIV_500",1}
+    };
+  };
+  class RF: RM {};
+
+  class GPMG: baseUnit {
+    weapons[] = {
+      {"CUP_lmg_PKMN",
+        {"150rnd_762x54_box","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"150rnd_762x54_box",1},
+      {"16rnd_9x21_mag",3},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+	  {"CUP_muzzle_snds_KZRZP_PK",1},
+      {"150rnd_762x54_box",3},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+  class MG: GPMG {};
+
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_rpk74",
+        {"rhs_75Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"rhs_75Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_75Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
+
+  class GPMGA: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKM",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "binocular"
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89",4},
+      {"rhs_30Rnd_762x39mm_tracer",2},
+      {"SmokeShell",2},
+      {"handgrenade",2},
+      {"150rnd_762x54_box",2},	  
+      {"150rnd_762x54_box_tracer",2}
+    };
+  };
+
+  class PT: baseUnit {
+
+    weapons[] = {
+      {"CUP_smg_Bizon",
+        {"CUP_64Rnd_9x19_Bizon_M","ace_acc_pointer_green"}
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      }
+    };
+
+    headgear[] = {
+      "rhsusf_hgu56p_visor_white",
+      "rhsusf_hgu56p_black",
+      "rhsusf_hgu56p_visor_mask_pink"
+      };
+
+    goggles[] = {rhs_balaclava1_olive};
+
+    vest[] = {"v_tacChestrig_oli_f"};
+    vestContents[] = {
+      {"acre_prc148",1},
+      {"CUP_64Rnd_9x19_Bizon_M",3},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[] = {"b_fieldpack_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"SmokeShell",2},
+      {"CUP_64Rnd_9x19_Bizon_M",3},
+      {"16rnd_9x21_mag",2},	  
+      {"SmokeShellgreen",2},
+      {"handgrenade",2},
+      {"Chemlight_green",2},
+      {"ace_ir_strobe_item",1},
+      {"Toolkit",1},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class PILOT: PT {};
+
+  class LauncherCrate {
+    vehCargoWeapons[] = {
+      {"rhs_weap_rpg26",10},
+	  {"rhs_weap_rshg2",4},
+      {"rhs_weap_rpg7",2},
+      {"ACE_Vector",2}
+    };
+    vehCargoMagazines[] = {
+      {"rhs_rpg7_og7v_mag",6},
+      {"rhs_rpg7_pg7v_mag",6},
+	  {"rhs_rpg7_tbg7v_mag",6},
+      {"rhs_rpg7_pg7vr_mag",6}
+    };
+    vehCargoRucks[] = {
+      {"b_carryall_ghex_f",2}
+    };
+  };
+  class LargeGearCrate {
+    vehCargoWeapons[] = {
+      {"rhs_weap_rpg26",6},
+      {"ACE_Vector",2}
+    };
+    vehCargoMagazines[] = {
+      {"rhs_30Rnd_762x39mm_89",40},
+      {"rhs_30Rnd_762x39mm_tracer",10},
+      {"rhs_75Rnd_762x39mm_89",20},
+      {"rhs_10Rnd_762x54mmR_7N14",10},
+      {"150rnd_762x54_box",8},
+      {"150rnd_762x54_box_tracer",2},
+      {"handgrenade",20},
+      {"SmokeShell",10},
+      {"rhs_vog25",15},
+	  {"rhs_vog25p",15},
+	  {"rhs_vg40tb",10},
+      {"DemoCharge_Remote_Mag",8}
+    };
+    vehCargoItems[] = {
+      {"ToolKit",1},
+      {"ACE_M26_Clacker",4},
+      {"ACE_DefusalKit",2},
+      {"ACE_fieldDressing",20},
+      {"ACE_packingBandage",20},
+      {"ACE_quikclot",20},
+      {"ACE_Tourniquet",8},
+      {"ACE_splint",4},
+      {"ACE_morphine",4},
+      {"ACE_epinephrine",4},
+      {"ACE_adenosine",4},
+      {"ACE_salineIV",4},      
+      {"ACE_salineIV_500",4},
+      {"ACE_Flashlight_MX991",4},
+      {"ACE_MapTools",4}
+    };
+    vehCargoRucks[] = {
+      {"b_carryall_ghex_f",4}
+    };
+  };
+};

--- a/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_rus.hpp
+++ b/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_rus.hpp
@@ -1,4 +1,4 @@
-  class CDF_des {
+  class CDF_rus {
     class BaseUnit {
       ace_earplugs = 1;
       allowPlayerGoggles = 0;
@@ -6,28 +6,35 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         }
       };
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhs_booniehat2_marpatd"};
+      headgear[] = {
+        "H_HelmetAggressor_cover_F",
+        "H_HelmetAggressor_F"
+      };
 
       goggles[] = {
+        "rhsusf_shemagh_gogg_grn",
+        "rhsusf_shemagh2_gogg_grn",
+        "rhsusf_shemagh_gogg_od",
+        "rhsusf_shemagh2_gogg_od",
         "rhsusf_shemagh_gogg_tan",		
         "rhsusf_shemagh2_gogg_tan"
       };
 
-      uniform[] = {"rhs_uniform_emr_des_patchless"};
+      uniform[] = {"U_O_R_Gorka_01_F"};
       uniformContents[] = {
         {"ACE_fieldDressing",4},
         {"ACE_elasticBandage",4},
@@ -40,9 +47,9 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {v_tacchestrig_grn_f};
+      vest[] = {V_CarrierRigKBT_01_light_Olive_F};
       vestContents[] = {
-        {"CUP_20Rnd_762x51_B_SCAR",6},
+        {"rhs_30Rnd_545x39_7N22_AK",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
@@ -52,8 +59,8 @@
       backpack[] = {"b_kitbag_rgr"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsgref_sdn6_silencer", 1},
-        {"CUP_20Rnd_762x51_B_SCAR",4},
+        {"rhs_acc_dtk4short", 1},
+        {"rhs_30Rnd_545x39_7N22_AK",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,21 +70,21 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","rhsusf_acc_su230","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","rhsusf_acc_su230","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +94,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,21 +109,21 @@
   class TL: SL {
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +132,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,22 +148,22 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -168,8 +175,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -185,22 +192,22 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -212,9 +219,9 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -227,9 +234,9 @@
     backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -238,18 +245,18 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"cup_arifle_mk20",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
+      {"srifle_DMR_05_blk_F",
+        {"10Rnd_93x64_DMR_05_Mag","ace_acc_pointer_green","optic_ams","rhs_acc_harris_swivel"}
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"10Rnd_93x64_DMR_05_Mag",5},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -259,9 +266,8 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"optic_tws_mg",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_93mmg",1},
+      {"10Rnd_93x64_DMR_05_Mag",5},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -272,19 +278,18 @@
   class MGL: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m32",
-        {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
+      {"CUP_glaunch_6G30",
+        {"CUP_6Rnd_HE_GP25_M"}
       },
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"rhsusf_mag_6rnd_m433_hedp",2},
-      {"rhsusf_mag_6rnd_m441_he",1},
+      {"CUP_6Rnd_HE_GP25_M",2},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -294,9 +299,7 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_mag_6rnd_m433_hedp",2},
-      {"rhsusf_mag_6rnd_m441_he",1},
-      {"rhsusf_mag_6rnd_m714_white",2},
+      {"CUP_6Rnd_HE_GP25_M",4},
       {"16rnd_9x21_mag",4},
       {"handgrenade",2},
       {"SmokeShell",2}
@@ -307,21 +310,21 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_cqc_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_AK107_GL_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_vog25","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_AK74M_GL_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_vog25","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         }
       };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -329,13 +332,14 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"cup_1rnd_hedp_m203",12},
-      {"cup_1rnd_he_m203",12},
-      {"rhs_mag_m714_white", 4}
+      {"rhs_vog25",12},
+      {"rhs_vog25p",8},
+      {"rhs_vg25tb",4},
+      {"rhs_vg40md", 4}
     };
   };
   class UGL: GN {};
@@ -343,23 +347,23 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_AK105_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
-      {"launch_MRAWS_green_rail_F",
-        {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
+      {"launch_RPG32_green_F",
+        {"RPG32_F", "ace_acc_pointer_green"}
       }
     };
     backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
-      {"MRAWS_HEAT55_F", 1},
-      {"MRAWS_HE_F", 2}
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
+      {"RPG32_F", 1},
+      {"RPG32_HE_F", 2}
     };
   };
 
@@ -367,14 +371,14 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
@@ -383,30 +387,30 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
-      {"MRAWS_HEAT55_F", 2},
-      {"MRAWS_HE_F", 2}
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
+      {"RPG32_F", 2},
+      {"RPG32_HE_F", 2}
     };
   };
 
   class HAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_AK105_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
-      {"launch_o_titan_short_f",
+      {"launch_I_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
       {"Titan_AT", 1}
     };
   };
@@ -415,14 +419,14 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_mx2a"
@@ -431,8 +435,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -440,12 +444,12 @@
 
   class ME: baseUnit {
     ace_medic = 2;
-    vest[] = {"V_SmershVest_01_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -468,11 +472,11 @@
   class RM: baseUnit {
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 4},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"150rnd_762x51_box",1},
+      {"150rnd_762x54_box",1},      
       {"ACE_salineIV_500",1}
     };
   };
@@ -480,17 +484,17 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"cup_lmg_mk48_nohg_tan",
-        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
+      {"CUP_lmg_Pecheneg",
+        {"150rnd_762x54_box","ace_acc_pointer_green","rhs_acc_ekp8_02d"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
       }
     };
-    vest[] = {"V_SmershVest_01_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"150rnd_762x51_box",1},
+      {"150rnd_762x54_box",1},
       {"16rnd_9x21_mag",3},
       {"ace_maptools",1}
     };
@@ -498,23 +502,47 @@
     backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_h_mg_blk_f",1},
-      {"150rnd_762x51_box",4},
+      {"CUP_muzzle_snds_KZRZP_PK",1},
+      {"150rnd_762x54_box",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class LMG: GPMG {};
+  class MG: GPMG {};
 
-  class MG: GPMG {}; 
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_RPK74M_railed",
+        {"CUP_60Rnd_545x39_AK74M_M","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"CUP_60Rnd_545x39_AK74M_M",4},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"rhs_acc_dtk4short",1},
+      {"CUP_60Rnd_545x39_AK74M_M",8},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
+      {"CUP_arifle_AK107_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "binocular"
@@ -523,23 +551,23 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",2},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK",4},
+      {"rhs_30Rnd_545x39_AK_green",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"150rnd_762x51_box",2},	  
-      {"150rnd_762x51_box_tracer",2}
+      {"150rnd_762x54_box",2},	  
+      {"150rnd_762x54_box_tracer",1}
     };
   };
 
   class PT: baseUnit {
 
     weapons[] = {
-      {"cup_smg_mac10_rail",
-        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      {"CUP_arifle_AKS74U_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"}
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       }
     };
@@ -555,7 +583,7 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhs_30Rnd_545x39_7N22_AK",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
@@ -564,7 +592,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhs_30Rnd_545x39_7N22_AK",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -598,12 +626,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",60},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
-      {"150rnd_762x51_box",20},
+      {"rhs_30Rnd_545x39_7N22_AK",40},
+      {"rhs_30Rnd_545x39_AK_green",10},
+      {"CUP_60Rnd_545x39_AK74M_M",20},
+      {"10Rnd_93x64_DMR_05_Mag",10},
+      {"150rnd_762x54_box",8},
+      {"150rnd_762x54_box_tracer",2},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"cup_1rnd_hedp_m203",20},
+      {"rhs_vog25",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}

--- a/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_wdl.hpp
+++ b/CO18_CZ_Malden_V29.Malden/tb3/murk/cdf_wdl.hpp
@@ -4,11 +4,16 @@
       allowPlayerGoggles = 0;
       ace_medic = 1;
 
-      weapons[] = {
-        {"rhs_weap_m16a4_imod_grip",
-          {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"}
+    weapons[] = {
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
         },
-        {"hgun_p07_khk_f",
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
@@ -47,7 +52,7 @@
 
       vest[] = {V_SmershVest_01_F};
       vestContents[] = {
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+        {"CUP_30Rnd_556x45_Emag",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
@@ -58,7 +63,7 @@
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
         {"rhsusf_acc_rotex5_grey", 1},
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+        {"CUP_30Rnd_556x45_Emag",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -67,17 +72,22 @@
   class SL: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "rhsusf_acc_su230","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -89,7 +99,7 @@
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -101,17 +111,22 @@
   class ZEUS: SL {};
   class TL: SL {
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -123,7 +138,7 @@
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -135,18 +150,23 @@
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio","B_UavTerminal"};
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -155,11 +175,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -168,15 +188,21 @@
       {"ACE_UAVBattery",2}
     };
   };
+
   class FSO: DFO {};
   class FO: DFO {
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
@@ -184,7 +210,7 @@
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -193,12 +219,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -208,32 +234,31 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
   };
 
-  class DM: baseUnit {
+  class HRF: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_sr25_ec",
-        {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a","rhsusf_acc_harris_bipod"}
+      {"CUP_arifle_Mk17_CQC_SFG_woodland",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_tws_mg"}
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
     };
 
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",6},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -242,9 +267,43 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
       {"rhsgref_sdn6_silencer",1},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",4},
-      {"rhsusf_20Rnd_762x51_sr25_M62_Mag",2},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_arifle_mk20_woodland",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_ams_khk","bipod_02_f_lush"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_vector"
+    };
+
+    vest[] = {"V_SmershVest_01_radio_F"};
+    vestContents[] = {
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -258,7 +317,7 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_khk_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
@@ -274,7 +333,7 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_mag_6rnd_m433_hedp",2},
@@ -289,17 +348,22 @@
   class GN: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_M203",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      }
-    };
+      {
+        {"CUP_arifle_Mk16_STD_EGLM_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag","cup_1rnd_hedp_m203"}
+        },
+        {"CUP_arifle_Mk16_CQC_EGLM_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag","cup_1rnd_hedp_m203"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        }
+      };
 
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",8},
+      {"CUP_30Rnd_556x45_Emag",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -308,11 +372,11 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhs_mag_m433_hedp",12},
-      {"rhs_mag_m441_he",12},
+      {"cup_1rnd_hedp_m203",12},
+      {"cup_1rnd_he_m203",12},
       {"rhs_mag_m714_white", 4}
     };
   };
@@ -321,10 +385,10 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
+      {"CUP_arifle_Mk16_CQC_FG_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
@@ -335,7 +399,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -344,20 +408,25 @@
   class MATA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -366,10 +435,10 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
+      {"CUP_arifle_Mk16_CQC_FG_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
@@ -379,7 +448,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"Titan_AT", 1}
     };
   };
@@ -387,20 +456,25 @@
   class HATA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
+      "ace_mx2a"
     };
     
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -409,11 +483,11 @@
   class ME: baseUnit {
     ace_medic = 2;
     vest[] = {"V_SmershVest_01_F"};
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -437,10 +511,10 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 6},
+      {"CUP_30Rnd_556x45_Emag", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote",1},
+      {"150Rnd_556x45_Drum_Green_Mag_f",1},
       {"ACE_salineIV_500",1}
     };
   };
@@ -448,25 +522,26 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_m60e4",
+        {"rhsusf_100Rnd_762x51_m61_ap","ace_acc_pointer_green","Optic_ERCO_blk_f"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"o_nvgoggles_grn_f",1},
+      {"rhsusf_100Rnd_762x51_m61_ap",3},
       {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
     backpack[]={"b_kitbag_sgg"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"rhsusf_100Rnd_762x51_m61_ap",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
@@ -476,15 +551,15 @@
   class LMG: baseUnit {
  
     weapons[] = {
-      {"rhs_weap_m249_light_S_vfg2",
-        {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote","rhsusf_acc_anpeq15side_bk","optic_Holosight_blk_F","rhsusf_acc_grip4_bipod"},
+      {"CUP_arifle_Mk16_SV_woodland",
+        {"150Rnd_556x45_Drum_Green_Mag_F","ace_acc_pointer_green","optic_Holosight_khk_F","bipod_02_F_lush"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vestContents[] = {
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",2},
+      {"150Rnd_556x45_Drum_Green_Mag_F",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
       {"handgrenade",2},
@@ -492,8 +567,9 @@
     };
 
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",4},
+      {"150Rnd_556x45_Drum_Green_Mag_F",6},
       {"SmokeShell",2},
       {"handgrenade",2}
     };   
@@ -502,23 +578,24 @@
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F"},
+      {"CUP_arifle_Mk16_SV_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F","bipod_02_F_lush"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
+      {"rhsusf_100Rnd_762x51_m61_ap",4},	  
       {"rhsusf_100Rnd_762x51_m62_tracer",2}
     };
   };
@@ -526,11 +603,11 @@
   class PT: baseUnit {
 
     weapons[] = {
-      {"smg_03c_tr_black",
-        {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
+      {"cup_smg_mac10_rail",
+        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
       },
-      {"hgun_p07_khk_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       }
     };
 
@@ -545,15 +622,16 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"50rnd_570x28_smg_03",2},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
-    backpack[] = {"b_tacticalpack_oli"};
+    backpack[] = {"b_fieldpack_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"50rnd_570x28_smg_03",4},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -563,7 +641,9 @@
       {"ace_microdagr",1}
     };
   };
+
   class PILOT: PT {};
+
   class LauncherCrate {
     vehCargoWeapons[] = {
       {"rhs_weap_m72a7",10},
@@ -576,7 +656,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_fieldpack_green_f",2}
+      {"b_carryall_green_f",2}
     };
   };
   class LargeGearCrate {
@@ -585,15 +665,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",40},
+      {"CUP_30Rnd_556x45_Emag",40},
       {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",10},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",10},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",10},
-      {"rhsusf_20Rnd_762x51_SR25_m62_Mag",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
+      {"150Rnd_556x45_Drum_Green_Mag_F",10},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",10},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",4},
+      {"rhsusf_100Rnd_762x51_m61_ap",8},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"rhs_mag_m433_hedp",20},
+      {"cup_1rnd_hedp_m203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -616,7 +696,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_carryall_oli",4}
+      {"b_carryall_green_f",4}
     };
   };
 };

--- a/CO18_CZ_Malden_V29.Malden/tb3/murk/loadouts.hpp
+++ b/CO18_CZ_Malden_V29.Malden/tb3/murk/loadouts.hpp
@@ -1,3 +1,6 @@
 #include "cdf_blk.hpp"
 #include "cdf_des.hpp"
 #include "cdf_wdl.hpp"
+#include "cdf_rus.hpp"
+#include "cdf_liz.hpp"
+#include "cdf_jng.hpp"

--- a/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_blk.hpp
+++ b/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_blk.hpp
@@ -8,7 +8,7 @@
         {"arifle_msbs65_black_f",
           {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"}
         },
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
@@ -61,7 +61,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_erco_blk_f",},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -95,7 +95,7 @@
       {"arifle_msbs65_ubs_black_f",
         {"30rnd_65x39_caseless_msbs_mag","6rnd_12gauge_pellets","ace_acc_pointer_green", "optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -131,7 +131,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -152,10 +152,10 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
-      {"30rnd_65x39_caseless_msbs_mag",6},
+      {"30rnd_65x39_caseless_msbs_mag",4},
       {"SmokeShell",2},
-      {"SmokeshellRed", 2},
-      {"SmokeShellGreen", 2},
+      {"SmokeshellRed", 1},
+      {"SmokeShellGreen", 1},
       {"ace_microdagr",1},
       {"ITC_Land_B_AR2i_Packed",2},
       {"ACE_UAVBattery",2}
@@ -169,7 +169,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green", "optic_Holosight_blk_F",},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
@@ -201,7 +201,7 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"crab_radiobag_01_black_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
@@ -212,21 +212,20 @@
     };
   };
 
-  class DM: baseUnit {
+  class HRF: baseUnit {
 
     weapons[] = {
-      {"srifle_dmr_03_f",
-        {"ace_20rnd_762x51_mk319_mod_0_mag","ace_acc_pointer_green","rhsusf_acc_su230a","rhs_acc_harris_swivel"}
+      {"CUP_arifle_Mk17_CQC_SFG_black",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_tws_mg"}
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
     };
 
-    vest[] = {"V_platecarrier2_blk"};
+    vest[] = {"V_platecarrier1_blk"};
     vestContents[] = {
-      {"ace_20rnd_762x51_mk319_mod_0_mag",6},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -235,9 +234,43 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_b",1},
-      {"ace_20rnd_762x51_mk319_mod_0_mag",4},
-      {"ace_20rnd_762x51_mag_tracer",2},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_arifle_mk20_black",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_ams","bipod_02_f_blk"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_vector"
+    };
+
+    vest[] = {"V_platecarrier1_blk"};
+    vestContents[] = {
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -251,7 +284,7 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
@@ -279,13 +312,44 @@
     };
   };
 
+  class SMG: baseUnit {
+
+    weapons[] = {
+      {"rhsusf_weap_mp7a2",
+        {"rhsusf_mag_40rnd_46x30_jhp","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      }
+    };
+
+    vest[] = {"V_platecarrier1_blk"};
+    vestContents[] = {
+      {"rhsusf_mag_40rnd_46x30_jhp",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_viperlightharness_blk_f"};
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"rhsusf_mag_40rnd_46x30_jhp",6},
+      {"ace_cts9",2},
+      {"ace_m84",2},
+      {"16rnd_9x21_mag",4},
+      {"handgrenade",4}
+    };
+  };
+
   class GN: baseUnit {
 
     weapons[] = {
       {"arifle_msbs65_gl_black_f",
         {"30rnd_65x39_caseless_msbs_mag", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F", "rhsusf_acc_grip1"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       }
     };
@@ -317,13 +381,15 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
+    vest[] = {"V_tacvestir_blk"};
+
     backpack[]={"b_viperlightharness_blk_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
@@ -340,7 +406,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -362,13 +428,15 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
+    vest[] = {"V_tacvestir_blk"};
+
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f",1},
@@ -383,7 +451,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
@@ -406,7 +474,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f", 1},
-      {"30rnd_65x39_caseless_msbs_mag",6},
+      {"30rnd_65x39_caseless_msbs_mag",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -441,25 +509,25 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_mk48_nohg",
+        {"150rnd_762x51_box","rhsusf_acc_anpeq15side_bk","Optic_ERCO_blk_f"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vest[] = {"V_tacvestir_blk"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
-      {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
+      {"150rnd_762x51_box",2},
+      {"16rnd_9x21_mag",1},
       {"ace_maptools",1}
     };
 
     backpack[]={"b_viperlightharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_black_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"150rnd_762x51_box",4},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
@@ -472,7 +540,7 @@
       {"lmg_mk200_black_f",
         {"200rnd_65x39_cased_box","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_harris_swivel"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
@@ -480,11 +548,11 @@
     vestContents[] = {
       {"200rnd_65x39_cased_box",2},
       {"16rnd_9x21_mag",2},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
       {"200rnd_65x39_cased_box",4},
       {"SmokeShell",2},
@@ -498,7 +566,7 @@
       {"arifle_msbs65_black_f",
         {"30rnd_65x39_caseless_msbs_mag","ace_acc_pointer_green","optic_Holosight_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
@@ -506,13 +574,14 @@
 
     backpack[]={"b_viperharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_65_ti_blk_f",1},
       {"30rnd_65x39_caseless_msbs_mag",4},
       {"30rnd_65x39_caseless_msbs_mag_tracer",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
-      {"rhsusf_100Rnd_762x51_m62_tracer",2}
+      {"150rnd_762x51_box",2},	  
+      {"150rnd_762x51_box_tracer",2}
     };
   };
 
@@ -522,7 +591,7 @@
       {"smg_03c_tr_black",
         {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
@@ -543,6 +612,7 @@
 
     backpack[] = {"b_viperharness_blk_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
       {"50rnd_570x28_smg_03",4},
       {"16rnd_9x21_mag",2},	  
@@ -581,8 +651,8 @@
       {"200rnd_65x39_cased_box",10},
       {"ace_20rnd_762x51_mk319_mod_0_mag",10},
       {"ace_20rnd_762x51_mag_tracer",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
-      {"rhsusf_100Rnd_762x51_m62_tracer",4},
+      {"150rnd_762x51_box",8},
+      {"150rnd_762x51_box_tracer",4},
       {"handgrenade",20},
       {"SmokeShell",10},
       {"rhs_mag_m433_hedp",20},

--- a/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_des.hpp
+++ b/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_des.hpp
@@ -6,21 +6,21 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhsusf_protech_helmet_rhino"};
+      headgear[] = {"rhs_booniehat2_marpatd"};
 
       goggles[] = {
         "rhsusf_shemagh_gogg_tan",		
@@ -40,20 +40,20 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {V_platecarrier1_blk};
+      vest[] = {v_tacchestrig_grn_f};
       vestContents[] = {
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+        {"CUP_20Rnd_762x51_B_SCAR",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
         {"ace_maptools",1}
       };
 
-      backpack[] = {"b_viperlightharness_blk_f"};
+      backpack[] = {"b_kitbag_rgr"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsusf_acc_rotex5_grey", 1},
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+        {"rhsgref_sdn6_silencer", 1},
+        {"CUP_20Rnd_762x51_B_SCAR",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,21 +63,21 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +87,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,21 +102,21 @@
   class TL: SL {
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
-    vest[] = {"V_platecarrier1_blk"};
+        },
+        "ace_vector"
+      };
+    vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +125,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,22 +141,22 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
-    vest[] = {"V_platecarrier1_blk"};
+        },
+        "ace_vector"
+      };
+    vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -165,11 +165,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -178,28 +178,29 @@
       {"ACE_UAVBattery",2}
     };
   };
+
   class FSO: DFO {};
   class FO: DFO {
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
     weapons[] = {
       {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+        {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
     };
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -208,12 +209,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -223,12 +224,12 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
+      {"rhsgref_sdn6_silencer", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -237,18 +238,18 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_sr25_ec_d",
-        {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a","rhsusf_acc_harris_bipod"}
+      {"cup_arifle_mk20",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",6},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -257,9 +258,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
       {"rhsgref_sdn6_silencer",1},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",4},
-      {"rhsusf_20Rnd_762x51_sr25_M62_Mag",2},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -273,13 +275,13 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
     };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
       {"rhsusf_mag_6rnd_m433_hedp",2},
       {"rhsusf_mag_6rnd_m441_he",1},
@@ -289,7 +291,7 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_mag_6rnd_m433_hedp",2},
@@ -304,17 +306,22 @@
   class GN: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m4a1_M203s_d",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F"},
-      },
-      {"hgun_p07_f",
-        {"16rnd_9x21_mag"}
-      }
-    };
+      {
+        {"CUP_arifle_Mk17_cqc_EGLM",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        },
+        {"CUP_arifle_Mk17_STD_EGLM",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        }
+      };
 
-    vest[] = {"V_platecarrier1_blk"};
+    vest[] = {"v_tacchestrig_grn_f"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",8},
+      {"CUP_20Rnd_762x51_B_SCAR",6},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -322,12 +329,12 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhs_mag_m433_hedp",12},
-      {"rhs_mag_m441_he",12},
+      {"cup_1rnd_hedp_m203",12},
+      {"cup_1rnd_he_m203",12},
       {"rhs_mag_m714_white", 4}
     };
   };
@@ -336,26 +343,21 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        }
-      },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
-    backpack[]={"b_viperlightharness_blk_f"};
+    backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -365,24 +367,24 @@
 
     weapons[] = {
       {
-        {"rhs_weap_mk18_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+        },
+        "ace_vector"
+      };
     
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -391,16 +393,11 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
-        }
-      },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
@@ -408,8 +405,8 @@
     };
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"Titan_AT", 1}
     };
   };
@@ -418,24 +415,24 @@
 
     weapons[] = {
       {
-        {"rhs_weap_m4a1_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_CQC_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         },
-        {"rhs_weap_m4a1_blockii_kac_d",
-          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_mag_30Rnd_556x45_Mk262_PMAG","rhsusf_acc_grip1"}
+        {"CUP_arifle_Mk17_STD_FG",
+          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
         }
       },	
-        {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+        {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       },
-      "ace_vector"
+      "ace_mx2a"
     };
     
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 2},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -443,12 +440,12 @@
 
   class ME: baseUnit {
     ace_medic = 2;
-    vest[] = {"V_tacvestir_blk"};
-    backpack[]={"b_viperharness_blk_f"};
+    vest[] = {"V_SmershVest_01_F"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"rhsgref_sdn6_silencer", 1},
+      {"CUP_20Rnd_762x51_B_SCAR",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -471,11 +468,11 @@
   class RM: baseUnit {
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 6},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR", 4},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote",1},
+      {"150rnd_762x51_box",1},
       {"ACE_salineIV_500",1}
     };
   };
@@ -483,89 +480,67 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_mk48_nohg_tan",
+        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
-    vest[] = {"V_tacvestir_blk"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"o_nvgoggles_grn_f",1},
+      {"150rnd_762x51_box",1},
       {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_viperlightharness_blk_f"};
+    backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"150rnd_762x51_box",4},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class MG: GPMG {};
+  class LMG: GPMG {};
 
-  class LMG: baseUnit {
- 
-    weapons[] = {
-      {"rhs_weap_m249_light_S_vfg2",
-        {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote","rhsusf_acc_anpeq15side_bk","optic_Holosight_blk_F","rhsusf_acc_grip4_bipod"},
-      },
-      {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
-      }
-    };
-    vestContents[] = {
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",2},
-      {"SmokeShell",2},
-      {"16rnd_9x21_mag",2},
-      {"handgrenade",2},
-      {"ace_maptools",1}
-    };
-
-    backpackContents[] = {
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",4},
-      {"SmokeShell",2},
-      {"handgrenade",2}
-    };   
-  };
+  class MG: GPMG {}; 
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F"},
+      {"CUP_arifle_Mk17_CQC_FG",
+        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
       },
-      {"hgun_p07_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
     };
 
-    backpack[]={"b_viperharness_blk_f"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
-      {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
-      {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",2},
+      {"o_nvgoggles_grn_f",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"CUP_20Rnd_762x51_B_SCAR",2},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
-      {"rhsusf_100Rnd_762x51_m62_tracer",2}
+      {"150rnd_762x51_box",2},	  
+      {"150rnd_762x51_box_tracer",2}
     };
   };
 
   class PT: baseUnit {
 
     weapons[] = {
-      {"smg_03c_tr_black",
-        {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
+      {"cup_smg_mac10_rail",
+        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
       },
-      {"hgun_p07_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       }
     };
 
@@ -580,15 +555,16 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"50rnd_570x28_smg_03",2},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
-    backpack[] = {"b_tacticalpack_oli"};
+    backpack[] = {"b_fieldpack_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"50rnd_570x28_smg_03",4},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -598,7 +574,9 @@
       {"ace_microdagr",1}
     };
   };
+
   class PILOT: PT {};
+
   class LauncherCrate {
     vehCargoWeapons[] = {
       {"rhs_weap_m72a7",10},
@@ -611,7 +589,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_fieldpack_green_f",2}
+      {"b_carryall_green_f",2}
     };
   };
   class LargeGearCrate {
@@ -620,15 +598,12 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",40},
-      {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",10},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",10},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",10},
-      {"rhsusf_20Rnd_762x51_SR25_m62_Mag",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
+      {"CUP_20Rnd_762x51_B_SCAR",60},
+      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
+      {"150rnd_762x51_box",20},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"rhs_mag_m433_hedp",20},
+      {"cup_1rnd_hedp_m203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -651,7 +626,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_viperharness_blk_f",4}
+      {"b_carryall_green_f",4}
     };
   };
 };

--- a/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_jng.hpp
+++ b/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_jng.hpp
@@ -1,4 +1,4 @@
-  class CDF_des {
+  class CDF_jng {
     class BaseUnit {
       ace_earplugs = 1;
       allowPlayerGoggles = 0;
@@ -6,11 +6,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -20,14 +20,31 @@
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhs_booniehat2_marpatd"};
-
-      goggles[] = {
-        "rhsusf_shemagh_gogg_tan",		
-        "rhsusf_shemagh2_gogg_tan"
+      headgear[] = {
+        "h_bandanna_khk_hs",
+		"rhsusf_bowman_cap",
+		"h_cap_headphones",
+		"h_cap_oli_hs",
+        "H_Booniehat_tna_F",
+        "H_MilCap_tna_F"
       };
 
-      uniform[] = {"rhs_uniform_emr_des_patchless"};
+      goggles[] = {
+		"g_bandanna_oli",
+		"rhs_googles_clear",
+        "rhsusf_shemagh_grn",
+        "rhsusf_shemagh2_grn",
+        "rhsusf_shemagh_od",
+        "rhsusf_shemagh2_od",
+        "rhsusf_shemagh_tan",		
+        "rhsusf_shemagh2_tan"
+      };
+
+      uniform[] = {
+        "U_B_T_Soldier_F",
+        "U_B_T_Soldier_AR_F",
+        "U_B_T_Soldier_SL_F"
+      };
       uniformContents[] = {
         {"ACE_fieldDressing",4},
         {"ACE_elasticBandage",4},
@@ -40,20 +57,20 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {v_tacchestrig_grn_f};
+      vest[] = {V_SmershVest_01_F};
       vestContents[] = {
-        {"CUP_20Rnd_762x51_B_SCAR",6},
+        {"rhsgref_30rnd_556x45_vhs2",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
         {"ace_maptools",1}
       };
 
-      backpack[] = {"b_kitbag_rgr"};
+      backpack[] = {"b_carryall_green_f"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsgref_sdn6_silencer", 1},
-        {"CUP_20Rnd_762x51_B_SCAR",4},
+        {"muzzle_snds_m_khk_F", 1},
+        {"rhsgref_30rnd_556x45_vhs2",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,11 +80,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -75,9 +92,9 @@
       },
       "ace_vector"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +104,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,11 +119,11 @@
   class TL: SL {
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -114,9 +131,9 @@
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +142,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,11 +158,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -153,10 +170,10 @@
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -165,11 +182,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -185,11 +202,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -197,10 +214,10 @@
       },
       "Laserdesignator_03"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -209,12 +226,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -224,12 +241,12 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"crab_radiobag_01_wdl_f"};
+    backpack[]={"crab_radiobag_01_tropic_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"muzzle_snds_m_khk_F", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -238,8 +255,8 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"cup_arifle_mk20",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
+      {"srifle_DMR_03_khaki_F",
+        {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag","ace_acc_pointer_green","optic_ams_khk","rhs_acc_harris_swivel"}
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -247,9 +264,9 @@
       "ace_vector"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -259,9 +276,9 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"optic_tws_mg",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_B",1},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",4},
+	  {"ACE_20Rnd_762x51_Mag_Tracer",4},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -281,7 +298,7 @@
       "ace_yardage450"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"rhsusf_mag_6rnd_m433_hedp",2},
       {"rhsusf_mag_6rnd_m441_he",1},
@@ -307,11 +324,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_cqc_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_G36A_AG36_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","rhsgref_30rnd_556x45_vhs2","CUP_1Rnd_HE_M203"}
         },
-        {"CUP_arifle_Mk17_STD_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_G36K_RIS_AG36_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","rhsgref_30rnd_556x45_vhs2","CUP_1Rnd_HE_M203"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -319,23 +336,24 @@
         }
       };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhsgref_30rnd_556x45_vhs2",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"cup_1rnd_hedp_m203",12},
-      {"cup_1rnd_he_m203",12},
-      {"rhs_mag_m714_white", 4}
+      {"CUP_1Rnd_HE_M203",12},
+      {"CUP_1Rnd_HEDP_M203",12},
+      {"1_rnd_smoke_grenade_shell", 4}
     };
   };
   class UGL: GN {};
@@ -343,8 +361,8 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -353,11 +371,11 @@
         {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
       }
     };
-    backpack[]={"b_kitbag_rgr"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -367,11 +385,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -380,11 +398,11 @@
         "ace_vector"
       };
     
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -393,8 +411,8 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -403,10 +421,11 @@
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"Titan_AT", 1}
     };
   };
@@ -415,11 +434,11 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36A_RIS_wdl",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_G36K_RIS_wdl",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","cup_bipod_g36_wood","rhsgref_30rnd_556x45_vhs2"}
         }
       },	
         {"CUP_hgun_Duty",
@@ -428,11 +447,11 @@
       "ace_mx2a"
     };
     
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -444,8 +463,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"muzzle_snds_m_khk_F", 1},
+      {"rhsgref_30rnd_556x45_vhs2",6},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -466,13 +485,15 @@
   class MED: ME {};
 
   class RM: baseUnit {
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 4},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"150rnd_762x51_box",1},
+	  {"CUP_100Rnd_556x45_BetaCMag",1},	  
+      {"150rnd_762x51_box",1},      
       {"ACE_salineIV_500",1}
     };
   };
@@ -480,8 +501,8 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"cup_lmg_mk48_nohg_tan",
-        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
+      {"CUP_lmg_mk48_nohg_od",
+        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_khk_f"},
       },
       {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
@@ -495,24 +516,48 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_kitbag_rgr"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_h_mg_blk_f",1},
-      {"150rnd_762x51_box",4},
+      {"muzzle_snds_m_khk_F",1},
+      {"150rnd_762x51_box",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class LMG: GPMG {};
+  class MG: GPMG {};
 
-  class MG: GPMG {}; 
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_MG36_wdl",
+        {"CUP_100Rnd_556x45_BetaCMag","ace_acc_pointer_green","optic_Holosight_khk_F"},
+      },
+      {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"CUP_100Rnd_556x45_BetaCMag",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"muzzle_snds_m_khk_F",1},
+      {"CUP_100Rnd_556x45_BetaCMag",4},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
+      {"CUP_arifle_MG36_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","Optic_ERCO_khk_f"},
       },
       {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
@@ -520,12 +565,12 @@
       "binocular"
     };
 
-    backpack[]={"b_carryall_green_f"};
+    backpack[]={"B_Bergen_tna_F"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",2},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_m_khk_F",1},
+      {"rhsgref_30rnd_556x45_vhs2",4},
+      {"rhsgref_30rnd_556x45_vhs2_t",2},
       {"SmokeShell",2},
       {"handgrenade",2},
       {"150rnd_762x51_box",2},	  
@@ -536,10 +581,10 @@
   class PT: baseUnit {
 
     weapons[] = {
-      {"cup_smg_mac10_rail",
-        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      {"CUP_arifle_G36C_VFG_wdl",
+        {"rhsgref_30rnd_556x45_vhs2","ace_acc_pointer_green","optic_Holosight_khk_F"}
       },
-      {"CUP_hgun_Duty",
+      {"CUP_hgun_duty",
         {"16rnd_9x21_mag"}
       }
     };
@@ -555,7 +600,7 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhsgref_30rnd_556x45_vhs2",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
@@ -564,7 +609,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhsgref_30rnd_556x45_vhs2",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -589,7 +634,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_carryall_green_f",2}
+      {"B_Bergen_tna_F",2}
     };
   };
   class LargeGearCrate {
@@ -598,12 +643,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",60},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
-      {"150rnd_762x51_box",20},
+      {"rhsgref_30rnd_556x45_vhs2",40},
+      {"rhsgref_30rnd_556x45_vhs2_t",10},
+      {"CUP_100Rnd_556x45_BetaCMag",20},
+      {"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",10},
+      {"150rnd_762x51_box",8},
+      {"150rnd_762x51_box_tracer",2},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"cup_1rnd_hedp_m203",20},
+      {"CUP_1Rnd_HE_M203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -626,7 +674,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_carryall_green_f",4}
+      {"B_Bergen_tna_F",4}
     };
   };
 };

--- a/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_liz.hpp
+++ b/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_liz.hpp
@@ -1,0 +1,680 @@
+  class CDF_liz {
+    class BaseUnit {
+      ace_earplugs = 1;
+      allowPlayerGoggles = 0;
+      ace_medic = 1;
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        }
+      };
+
+      assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
+
+      headgear[] = {
+        "h_bandanna_khk_hs",
+		"rhsusf_bowman_cap",
+		"h_cap_headphones",
+		"h_cap_oli_hs",
+        "H_Booniehat_khk",
+        "H_MilCap_grn"
+      };
+
+      goggles[] = {
+		"g_bandanna_oli",
+		"rhs_googles_clear",
+        "rhsusf_shemagh_grn",
+        "rhsusf_shemagh2_grn",
+        "rhsusf_shemagh_od",
+        "rhsusf_shemagh2_od",
+        "rhsusf_shemagh_tan",		
+        "rhsusf_shemagh2_tan"
+      };
+
+      uniform[] = {
+        "rhsgref_uniform_altis_lizard",
+        "rhsgref_uniform_altis_lizard_olive"
+      };
+      uniformContents[] = {
+        {"ACE_fieldDressing",4},
+        {"ACE_elasticBandage",4},
+        {"ACE_quikclot",4},
+        {"ACE_morphine",2},
+        {"ACE_adenosine",1},
+        {"ACE_tourniquet",2},
+        {"ACE_Splint",2},
+        {"ACE_salineIV_500",1},
+        {"ACE_Flashlight_XL50",1}
+      };
+
+      vest[] = {V_HarnessO_ghex_F};
+      vestContents[] = {
+        {"rhs_30Rnd_762x39mm_89",6},
+        {"handgrenade",2},
+        {"SmokeShell",2},
+        {"16rnd_9x21_mag",2},
+        {"ace_maptools",1}
+      };
+
+      backpack[] = {"b_viperlightharness_ghex_f"};
+      backpackContents[] = {
+        {"CUP_nvg_pvs7",1},
+        {"rhs_acc_pbs1", 1},
+        {"rhs_30Rnd_762x39mm_89",4},
+        {"SmokeShell",2},
+        {"handgrenade",2}
+      };
+    };
+
+  class SL: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_acc_pso1m21"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_acc_pso1m21"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"acre_prc148",1},
+      {"16rnd_9x21_mag",2},
+      {"itc_land_tablet_rover",1},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"ace_ir_strobe_item",1},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 4},
+      {"SmokeShellGreen", 4},
+      {"ace_microdagr",1}
+    };
+  };
+  class PL: SL {};
+  class ZEUS: SL {};
+  class TL: SL {
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"acre_prc148",1},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"ace_ir_strobe_item",1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 4},
+      {"SmokeShellGreen", 4},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class DFO: SL {
+    assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio","B_UavTerminal"};
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "binocular"
+      };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"acre_prc148",2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"ace_microdagr",1},
+      {"ITC_Land_B_AR2i_Packed",2},
+      {"ACE_UAVBattery",2}
+    };
+  };
+
+  class FSO: DFO {};
+  class FO: DFO {
+    assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "Laserdesignator_03"
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"acre_prc148",1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"handgrenade", 2},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"SmokeshellRed", 2},
+      {"SmokeShellGreen", 2},
+      {"laserbatteries",2},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class RTO: baseUnit {
+    backpack[]={"crab_radiobag_01_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"handgrenade", 2},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"SmokeShell",2},
+      {"ACRE_PRC117F",1}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_srifle_svd",
+        {"rhs_10Rnd_762x54mmR_7N14","rhs_acc_pso1m2","cup_svd_camo_g"}
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_10Rnd_762x54mmR_7N14",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"CUP_muzzle_snds_KZRZP_SVD",1},
+      {"rhs_10Rnd_762x54mmR_7N14",6},
+	  {"ACE_10Rnd_762x54_Tracer_mag",4},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+  class DMR: DM {};
+
+  class MGL: baseUnit {
+
+    weapons[] = {
+      {"CUP_glaunch_6G30",
+        {"CUP_6Rnd_HE_GP25_M"}
+      },
+        {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_yardage450"
+    };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"CUP_6Rnd_HE_GP25_M",2},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"CUP_6Rnd_HE_GP25_M",4},
+      {"16rnd_9x21_mag",4},
+      {"handgrenade",2},
+      {"SmokeShell",2}
+    };
+  };
+
+  class GN: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM_gl",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_vog25"}
+        },
+        {"CUP_arifle_AKMS_gl",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89","rhs_vog25"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        }
+      };
+
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"rhs_30Rnd_762x39mm_89",8},
+      {"handgrenade", 2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"handgrenade",2},
+      {"rhs_vog25",12},
+      {"rhs_vog25p",8},
+	  {"rhs_vg40tb",4},
+      {"1_rnd_smoke_grenade_shell", 4}
+    };
+  };
+  class UGL: GN {};
+
+  class MAT: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKMS",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      {"rhs_weap_rpg7",
+        {"rhs_rpg7_pg7v_mag"}
+      }
+    };
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7v_mag", 1},
+      {"rhs_rpg7_og7v_mag", 2}
+    };
+  };
+
+  class MATA: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7v_mag", 2},
+      {"rhs_rpg7_og7v_mag", 2}
+    };
+  };
+
+  class HAT: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKMS",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      {"rhs_weap_rpg7",
+        {"rhs_rpg7_og7v_mag"}
+      }
+    };
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7vr_mag", 2},
+      {"rhs_rpg7_og7v_mag", 1}
+    };
+  };
+
+  class HATA: baseUnit {
+
+    weapons[] = {
+      {
+        {"CUP_arifle_AKM",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        },
+        {"CUP_arifle_AKMS",
+          {"ace_acc_pointer_green","rhs_30Rnd_762x39mm_89"}
+        }
+      },	
+        {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_yardage450"
+      };
+    
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"rhs_rpg7_pg7vr_mag", 2},
+	  {"rhs_rpg7_og7v_mag",1},
+      {"rhs_rpg7_tbg7v_mag", 1}
+    };
+  };
+
+  class ME: baseUnit {
+    ace_medic = 2;
+    vest[] = {"V_HarnessO_ghex_F"};
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1", 1},
+      {"rhs_30Rnd_762x39mm_89",6},
+      {"ACE_fieldDressing",15},
+      {"ACE_packingBandage",10},
+      {"ACE_quikclot",15},
+      {"ACE_elasticBandage",15},
+      {"ACE_morphine",8},
+      {"ACE_epinephrine",8},
+      {"ACE_adenosine",8},
+      {"ACE_salineIV_250",4},
+      {"ACE_salineiv_500",4},
+      {"ACE_salineiv",2},
+      {"ACE_bloodIV",4},
+      {"ACE_personalAidKit",1},
+      {"ACE_surgicalKit",1},
+      {"ACE_splint",8},
+      {"ACE_tourniquet",5}
+    };
+  };
+  class MED: ME {};
+
+  class RM: baseUnit {
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89", 6},
+      {"handgrenade",4},
+      {"SmokeShell",2},
+	  {"rhs_75Rnd_762x39mm_89",1},	  
+      {"150rnd_762x54_box",1},      
+      {"ACE_salineIV_500",1}
+    };
+  };
+  class RF: RM {};
+
+  class GPMG: baseUnit {
+    weapons[] = {
+      {"CUP_lmg_PKMN",
+        {"150rnd_762x54_box","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vest[] = {"V_HarnessO_ghex_F"};
+    vestContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"150rnd_762x54_box",1},
+      {"16rnd_9x21_mag",3},
+      {"ace_maptools",1}
+    };
+
+    backpack[]={"b_viperlightharness_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+	  {"CUP_muzzle_snds_KZRZP_PK",1},
+      {"150rnd_762x54_box",3},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+  class MG: GPMG {};
+
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_rpk74",
+        {"rhs_75Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"rhs_75Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_75Rnd_762x39mm_89",4},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
+
+  class GPMGA: baseUnit {
+
+    weapons[] = {
+      {"CUP_arifle_AKM",
+        {"rhs_30Rnd_762x39mm_89","ace_acc_pointer_green"},
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      },
+      "binocular"
+    };
+
+    backpack[]={"b_carryall_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"rhs_acc_pbs1",1},
+      {"rhs_30Rnd_762x39mm_89",4},
+      {"rhs_30Rnd_762x39mm_tracer",2},
+      {"SmokeShell",2},
+      {"handgrenade",2},
+      {"150rnd_762x54_box",2},	  
+      {"150rnd_762x54_box_tracer",2}
+    };
+  };
+
+  class PT: baseUnit {
+
+    weapons[] = {
+      {"CUP_smg_Bizon",
+        {"CUP_64Rnd_9x19_Bizon_M","ace_acc_pointer_green"}
+      },
+      {"hgun_rook40_f",
+        {"16rnd_9x21_mag"}
+      }
+    };
+
+    headgear[] = {
+      "rhsusf_hgu56p_visor_white",
+      "rhsusf_hgu56p_black",
+      "rhsusf_hgu56p_visor_mask_pink"
+      };
+
+    goggles[] = {rhs_balaclava1_olive};
+
+    vest[] = {"v_tacChestrig_oli_f"};
+    vestContents[] = {
+      {"acre_prc148",1},
+      {"CUP_64Rnd_9x19_Bizon_M",3},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpack[] = {"b_fieldpack_ghex_f"};
+    backpackContents[] = {
+      {"CUP_nvg_pvs7",1},
+      {"SmokeShell",2},
+      {"CUP_64Rnd_9x19_Bizon_M",3},
+      {"16rnd_9x21_mag",2},	  
+      {"SmokeShellgreen",2},
+      {"handgrenade",2},
+      {"Chemlight_green",2},
+      {"ace_ir_strobe_item",1},
+      {"Toolkit",1},
+      {"ace_microdagr",1}
+    };
+  };
+
+  class PILOT: PT {};
+
+  class LauncherCrate {
+    vehCargoWeapons[] = {
+      {"rhs_weap_rpg26",10},
+	  {"rhs_weap_rshg2",4},
+      {"rhs_weap_rpg7",2},
+      {"ACE_Vector",2}
+    };
+    vehCargoMagazines[] = {
+      {"rhs_rpg7_og7v_mag",6},
+      {"rhs_rpg7_pg7v_mag",6},
+	  {"rhs_rpg7_tbg7v_mag",6},
+      {"rhs_rpg7_pg7vr_mag",6}
+    };
+    vehCargoRucks[] = {
+      {"b_carryall_ghex_f",2}
+    };
+  };
+  class LargeGearCrate {
+    vehCargoWeapons[] = {
+      {"rhs_weap_rpg26",6},
+      {"ACE_Vector",2}
+    };
+    vehCargoMagazines[] = {
+      {"rhs_30Rnd_762x39mm_89",40},
+      {"rhs_30Rnd_762x39mm_tracer",10},
+      {"rhs_75Rnd_762x39mm_89",20},
+      {"rhs_10Rnd_762x54mmR_7N14",10},
+      {"150rnd_762x54_box",8},
+      {"150rnd_762x54_box_tracer",2},
+      {"handgrenade",20},
+      {"SmokeShell",10},
+      {"rhs_vog25",15},
+	  {"rhs_vog25p",15},
+	  {"rhs_vg40tb",10},
+      {"DemoCharge_Remote_Mag",8}
+    };
+    vehCargoItems[] = {
+      {"ToolKit",1},
+      {"ACE_M26_Clacker",4},
+      {"ACE_DefusalKit",2},
+      {"ACE_fieldDressing",20},
+      {"ACE_packingBandage",20},
+      {"ACE_quikclot",20},
+      {"ACE_Tourniquet",8},
+      {"ACE_splint",4},
+      {"ACE_morphine",4},
+      {"ACE_epinephrine",4},
+      {"ACE_adenosine",4},
+      {"ACE_salineIV",4},      
+      {"ACE_salineIV_500",4},
+      {"ACE_Flashlight_MX991",4},
+      {"ACE_MapTools",4}
+    };
+    vehCargoRucks[] = {
+      {"b_carryall_ghex_f",4}
+    };
+  };
+};

--- a/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_rus.hpp
+++ b/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_rus.hpp
@@ -1,4 +1,4 @@
-  class CDF_des {
+  class CDF_rus {
     class BaseUnit {
       ace_earplugs = 1;
       allowPlayerGoggles = 0;
@@ -6,28 +6,35 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         }
       };
 
       assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
-      headgear[] = {"rhs_booniehat2_marpatd"};
+      headgear[] = {
+        "H_HelmetAggressor_cover_F",
+        "H_HelmetAggressor_F"
+      };
 
       goggles[] = {
+        "rhsusf_shemagh_gogg_grn",
+        "rhsusf_shemagh2_gogg_grn",
+        "rhsusf_shemagh_gogg_od",
+        "rhsusf_shemagh2_gogg_od",
         "rhsusf_shemagh_gogg_tan",		
         "rhsusf_shemagh2_gogg_tan"
       };
 
-      uniform[] = {"rhs_uniform_emr_des_patchless"};
+      uniform[] = {"U_O_R_Gorka_01_F"};
       uniformContents[] = {
         {"ACE_fieldDressing",4},
         {"ACE_elasticBandage",4},
@@ -40,9 +47,9 @@
         {"ACE_Flashlight_XL50",1}
       };
 
-      vest[] = {v_tacchestrig_grn_f};
+      vest[] = {V_CarrierRigKBT_01_light_Olive_F};
       vestContents[] = {
-        {"CUP_20Rnd_762x51_B_SCAR",6},
+        {"rhs_30Rnd_545x39_7N22_AK",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
@@ -52,8 +59,8 @@
       backpack[] = {"b_kitbag_rgr"};
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
-        {"rhsgref_sdn6_silencer", 1},
-        {"CUP_20Rnd_762x51_B_SCAR",4},
+        {"rhs_acc_dtk4short", 1},
+        {"rhs_30Rnd_545x39_7N22_AK",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -63,21 +70,21 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","rhsusf_acc_su230","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","Optic_ERCO_snd_f","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","rhsusf_acc_su230","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -87,9 +94,9 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -102,21 +109,21 @@
   class TL: SL {
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -125,10 +132,10 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -141,22 +148,22 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
       };
-    vest[] = {"V_SmershVest_01_radio_F"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -168,8 +175,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -185,22 +192,22 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
     };
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -212,9 +219,9 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -227,9 +234,9 @@
     backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
+      {"rhs_acc_dtk4short", 1},
       {"handgrenade", 2},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
@@ -238,18 +245,18 @@
   class DM: baseUnit {
 
     weapons[] = {
-      {"cup_arifle_mk20",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_ams_snd","bipod_02_F_hex"}
+      {"srifle_DMR_05_blk_F",
+        {"10Rnd_93x64_DMR_05_Mag","ace_acc_pointer_green","optic_ams","rhs_acc_harris_swivel"}
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_heavy_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"10Rnd_93x64_DMR_05_Mag",5},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -259,9 +266,8 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"optic_tws_mg",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"muzzle_snds_93mmg",1},
+      {"10Rnd_93x64_DMR_05_Mag",5},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -272,19 +278,18 @@
   class MGL: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m32",
-        {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
+      {"CUP_glaunch_6G30",
+        {"CUP_6Rnd_HE_GP25_M"}
       },
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
     };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"rhsusf_mag_6rnd_m433_hedp",2},
-      {"rhsusf_mag_6rnd_m441_he",1},
+      {"CUP_6Rnd_HE_GP25_M",2},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -294,9 +299,7 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsusf_mag_6rnd_m433_hedp",2},
-      {"rhsusf_mag_6rnd_m441_he",1},
-      {"rhsusf_mag_6rnd_m714_white",2},
+      {"CUP_6Rnd_HE_GP25_M",4},
       {"16rnd_9x21_mag",4},
       {"handgrenade",2},
       {"SmokeShell",2}
@@ -307,21 +310,21 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_cqc_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_AK107_GL_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_vog25","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_EGLM",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR","cup_1rnd_hedp_m203"}
+        {"CUP_arifle_AK74M_GL_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_vog25","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         }
       };
 
-    vest[] = {"v_tacchestrig_grn_f"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",6},
+      {"rhs_30Rnd_545x39_7N22_AK",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -329,13 +332,14 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"cup_1rnd_hedp_m203",12},
-      {"cup_1rnd_he_m203",12},
-      {"rhs_mag_m714_white", 4}
+      {"rhs_vog25",12},
+      {"rhs_vog25p",8},
+      {"rhs_vg25tb",4},
+      {"rhs_vg40md", 4}
     };
   };
   class UGL: GN {};
@@ -343,23 +347,23 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_AK105_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
-      {"launch_MRAWS_green_rail_F",
-        {"MRAWS_HEAT55_F", "ace_acc_pointer_green"}
+      {"launch_RPG32_green_F",
+        {"RPG32_F", "ace_acc_pointer_green"}
       }
     };
     backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
-      {"MRAWS_HEAT55_F", 1},
-      {"MRAWS_HE_F", 2}
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
+      {"RPG32_F", 1},
+      {"RPG32_HE_F", 2}
     };
   };
 
@@ -367,14 +371,14 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
         },
         "ace_vector"
@@ -383,30 +387,30 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
-      {"MRAWS_HEAT55_F", 2},
-      {"MRAWS_HE_F", 2}
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
+      {"RPG32_F", 2},
+      {"RPG32_HE_F", 2}
     };
   };
 
   class HAT: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight"},
+      {"CUP_arifle_AK105_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
-      {"launch_o_titan_short_f",
+      {"launch_I_titan_short_f",
         {"Titan_AT", "ace_acc_pointer_green"}
       }
     };
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
       {"Titan_AT", 1}
     };
   };
@@ -415,14 +419,14 @@
 
     weapons[] = {
       {
-        {"CUP_arifle_Mk17_CQC_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK107_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         },
-        {"CUP_arifle_Mk17_STD_FG",
-          {"ace_acc_pointer_green","optic_holosight","CUP_20Rnd_762x51_B_SCAR"}
+        {"CUP_arifle_AK105_railed",
+          {"ace_acc_pointer_green","optic_Holosight_blk_F","rhs_30Rnd_545x39_7N22_AK","rhs_acc_dtk2"}
         }
       },	
-        {"CUP_hgun_Duty",
+        {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "ace_mx2a"
@@ -431,8 +435,8 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 4},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -440,12 +444,12 @@
 
   class ME: baseUnit {
     ace_medic = 2;
-    vest[] = {"V_SmershVest_01_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer", 1},
-      {"CUP_20Rnd_762x51_B_SCAR",4},
+      {"rhs_acc_dtk4short", 1},
+      {"rhs_30Rnd_545x39_7N22_AK",6},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -468,11 +472,11 @@
   class RM: baseUnit {
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR", 4},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"150rnd_762x51_box",1},
+      {"150rnd_762x54_box",1},      
       {"ACE_salineIV_500",1}
     };
   };
@@ -480,17 +484,17 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"cup_lmg_mk48_nohg_tan",
-        {"150rnd_762x51_box","ace_acc_pointer_green","Optic_ERCO_snd_f"},
+      {"CUP_lmg_Pecheneg",
+        {"150rnd_762x54_box","ace_acc_pointer_green","rhs_acc_ekp8_02d"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
           {"16rnd_9x21_mag"}
       }
     };
-    vest[] = {"V_SmershVest_01_F"};
+    vest[] = {"V_CarrierRigKBT_01_light_Olive_F"};
     vestContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"150rnd_762x51_box",1},
+      {"150rnd_762x54_box",1},
       {"16rnd_9x21_mag",3},
       {"ace_maptools",1}
     };
@@ -498,23 +502,47 @@
     backpack[]={"b_kitbag_rgr"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"muzzle_snds_h_mg_blk_f",1},
-      {"150rnd_762x51_box",4},
+      {"CUP_muzzle_snds_KZRZP_PK",1},
+      {"150rnd_762x54_box",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
   };
-  class LMG: GPMG {};
+  class MG: GPMG {};
 
-  class MG: GPMG {}; 
+  class LMG: baseUnit {
+ 
+    weapons[] = {
+      {"CUP_arifle_RPK74M_railed",
+        {"CUP_60Rnd_545x39_AK74M_M","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
+      },
+      {"hgun_rook40_f",
+          {"16rnd_9x21_mag"}
+      }
+    };
+    vestContents[] = {
+      {"CUP_60Rnd_545x39_AK74M_M",4},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"rhs_acc_dtk4short",1},
+      {"CUP_60Rnd_545x39_AK74M_M",8},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };   
+  };
 
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"CUP_arifle_Mk17_CQC_FG",
-        {"CUP_20Rnd_762x51_B_SCAR","ace_acc_pointer_green","optic_holosight","bipod_02_F_hex"},
+      {"CUP_arifle_AK107_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"},
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       },
       "binocular"
@@ -523,23 +551,23 @@
     backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
-      {"rhsgref_sdn6_silencer",1},
-      {"CUP_20Rnd_762x51_B_SCAR",2},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",2},
+      {"rhs_acc_dtk4short",1},
+      {"rhs_30Rnd_545x39_7N22_AK",4},
+      {"rhs_30Rnd_545x39_AK_green",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"150rnd_762x51_box",2},	  
-      {"150rnd_762x51_box_tracer",2}
+      {"150rnd_762x54_box",2},	  
+      {"150rnd_762x54_box_tracer",1}
     };
   };
 
   class PT: baseUnit {
 
     weapons[] = {
-      {"cup_smg_mac10_rail",
-        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
+      {"CUP_arifle_AKS74U_railed",
+        {"rhs_30Rnd_545x39_7N22_AK","ace_acc_pointer_green","optic_Holosight_blk_F","rhs_acc_dtk2"}
       },
-      {"CUP_hgun_Duty",
+      {"hgun_rook40_f",
         {"16rnd_9x21_mag"}
       }
     };
@@ -555,7 +583,7 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhs_30Rnd_545x39_7N22_AK",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
@@ -564,7 +592,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"CUP_30Rnd_45ACP_MAC10_M",3},
+      {"rhs_30Rnd_545x39_7N22_AK",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -598,12 +626,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"CUP_20Rnd_762x51_B_SCAR",60},
-      {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR",10},
-      {"150rnd_762x51_box",20},
+      {"rhs_30Rnd_545x39_7N22_AK",40},
+      {"rhs_30Rnd_545x39_AK_green",10},
+      {"CUP_60Rnd_545x39_AK74M_M",20},
+      {"10Rnd_93x64_DMR_05_Mag",10},
+      {"150rnd_762x54_box",8},
+      {"150rnd_762x54_box_tracer",2},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"cup_1rnd_hedp_m203",20},
+      {"rhs_vog25",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}

--- a/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_wdl.hpp
+++ b/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/cdf_wdl.hpp
@@ -4,11 +4,16 @@
       allowPlayerGoggles = 0;
       ace_medic = 1;
 
-      weapons[] = {
-        {"rhs_weap_m16a4_imod_grip",
-          {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"}
+    weapons[] = {
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
         },
-        {"hgun_p07_khk_f",
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
         }
       };
@@ -47,7 +52,7 @@
 
       vest[] = {V_SmershVest_01_F};
       vestContents[] = {
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+        {"CUP_30Rnd_556x45_Emag",6},
         {"handgrenade",2},
         {"SmokeShell",2},
         {"16rnd_9x21_mag",2},
@@ -58,7 +63,7 @@
       backpackContents[] = {
         {"o_nvgoggles_grn_f",1},
         {"rhsusf_acc_rotex5_grey", 1},
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+        {"CUP_30Rnd_556x45_Emag",4},
         {"SmokeShell",2},
         {"handgrenade",2}
       };
@@ -67,17 +72,22 @@
   class SL: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "rhsusf_acc_su230","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","Optic_ERCO_khk_f","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
       },
       "ace_vector"
     };
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -89,7 +99,7 @@
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"ace_ir_strobe_item",1},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
@@ -101,17 +111,22 @@
   class ZEUS: SL {};
   class TL: SL {
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"acre_prc148",1},
       {"16rnd_9x21_mag",2},
@@ -123,7 +138,7 @@
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
       {"ace_ir_strobe_item",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 4},
       {"SmokeShellGreen", 4},
@@ -135,18 +150,23 @@
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio","B_UavTerminal"};
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
       {"acre_prc148",2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -155,11 +175,11 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -168,15 +188,21 @@
       {"ACE_UAVBattery",2}
     };
   };
+
   class FSO: DFO {};
   class FO: DFO {
     assignedItems[] = {"ItemMap","ItemCompass","ItemWatch","ItemRadio"};
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green", "optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "Laserdesignator_03"
@@ -184,7 +210,7 @@
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"handgrenade", 2},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
@@ -193,12 +219,12 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"SmokeshellRed", 2},
       {"SmokeShellGreen", 2},
@@ -208,32 +234,31 @@
   };
 
   class RTO: baseUnit {
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"crab_radiobag_01_wdl_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
       {"handgrenade", 2},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",6},
       {"SmokeShell",2},
       {"ACRE_PRC117F",1}
     };
   };
 
-  class DM: baseUnit {
+  class HRF: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_sr25_ec",
-        {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a","rhsusf_acc_harris_bipod"}
+      {"CUP_arifle_Mk17_CQC_SFG_woodland",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_tws_mg"}
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
     };
 
     vest[] = {"V_SmershVest_01_radio_F"};
     vestContents[] = {
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",6},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
       {"handgrenade",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
@@ -242,9 +267,43 @@
 
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
       {"rhsgref_sdn6_silencer",1},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",4},
-      {"rhsusf_20Rnd_762x51_sr25_M62_Mag",2},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
+      {"ACE_salineIV_500",1},
+      {"SmokeShell",2},
+      {"handgrenade",2}
+    };
+  };
+
+  class DM: baseUnit {
+
+    weapons[] = {
+      {"cup_arifle_mk20_woodland",
+        {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr","ace_acc_pointer_green","optic_ams_khk","bipod_02_f_lush"}
+      },
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
+      },
+      "ace_vector"
+    };
+
+    vest[] = {"V_SmershVest_01_radio_F"};
+    vestContents[] = {
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",6},
+      {"handgrenade",2},
+      {"SmokeShell",2},
+      {"16rnd_9x21_mag",2},
+      {"ace_maptools",1}
+    };
+
+    backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
+      {"optic_tws_mg",1},
+      {"rhsgref_sdn6_silencer",1},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",4},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",2},
       {"ACE_salineIV_500",1},
       {"SmokeShell",2},
       {"handgrenade",2}
@@ -258,7 +317,7 @@
       {"rhs_weap_m32",
         {"rhsusf_mag_6rnd_m433_hedp","ace_acc_pointer_green"}
       },
-      {"hgun_p07_khk_f",
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "ace_yardage450"
@@ -274,7 +333,7 @@
       {"ace_maptools",1}
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_mag_6rnd_m433_hedp",2},
@@ -289,17 +348,22 @@
   class GN: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_M203",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG", "rhs_mag_m441_he", "ace_acc_pointer_green", "optic_Holosight_blk_F"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      }
-    };
+      {
+        {"CUP_arifle_Mk16_STD_EGLM_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag","cup_1rnd_hedp_m203"}
+        },
+        {"CUP_arifle_Mk16_CQC_EGLM_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag","cup_1rnd_hedp_m203"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        }
+      };
 
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",8},
+      {"CUP_30Rnd_556x45_Emag",8},
       {"handgrenade", 2},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
@@ -308,11 +372,11 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhs_mag_m433_hedp",12},
-      {"rhs_mag_m441_he",12},
+      {"cup_1rnd_hedp_m203",12},
+      {"cup_1rnd_he_m203",12},
       {"rhs_mag_m714_white", 4}
     };
   };
@@ -321,10 +385,10 @@
   class MAT: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
+      {"CUP_arifle_Mk16_CQC_FG_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_MRAWS_green_rail_F",
@@ -335,7 +399,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"MRAWS_HEAT55_F", 1},
       {"MRAWS_HE_F", 2}
     };
@@ -344,20 +408,25 @@
   class MATA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
-        {"16rnd_9x21_mag"}
-      },
-      "ace_vector"
-    };
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
+          {"16rnd_9x21_mag"}
+        },
+        "ace_vector"
+      };
     
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"MRAWS_HEAT55_F", 2},
       {"MRAWS_HE_F", 2}
     };
@@ -366,10 +435,10 @@
   class HAT: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
+      {"CUP_arifle_Mk16_CQC_FG_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       {"launch_o_titan_short_f",
@@ -379,7 +448,7 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"Titan_AT", 1}
     };
   };
@@ -387,20 +456,25 @@
   class HATA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F","rhsusf_acc_grip1"},
-      },
-      {"hgun_p07_khk_f",
+      {
+        {"CUP_arifle_Mk16_STD_FG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        },
+        {"CUP_arifle_Mk16_CQC_AFG_woodland",
+          {"ace_acc_pointer_green","optic_Holosight_khk_F","CUP_30Rnd_556x45_Emag"}
+        }
+      },	
+        {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
-      "ace_vector"
+      "ace_mx2a"
     };
     
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 4},
+      {"CUP_30Rnd_556x45_Emag", 4},
       {"Titan_AT", 1},
       {"Titan_AP", 2}
     };
@@ -409,11 +483,11 @@
   class ME: baseUnit {
     ace_medic = 2;
     vest[] = {"V_SmershVest_01_F"};
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey", 1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",6},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"ACE_fieldDressing",15},
       {"ACE_packingBandage",10},
       {"ACE_quikclot",15},
@@ -437,10 +511,10 @@
     backpackContents[] = {
       {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG", 6},
+      {"CUP_30Rnd_556x45_Emag", 6},
       {"handgrenade",4},
       {"SmokeShell",2},
-      {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote",1},
+      {"150Rnd_556x45_Drum_Green_Mag_f",1},
       {"ACE_salineIV_500",1}
     };
   };
@@ -448,25 +522,26 @@
 
   class GPMG: baseUnit {
     weapons[] = {
-      {"rhs_weap_m240b",
-        {"rhsusf_100Rnd_762x51_m80a1epr","rhsusf_acc_anpeq15side_bk","rhsusf_acc_su230a"},
+      {"cup_lmg_m60e4",
+        {"rhsusf_100Rnd_762x51_m61_ap","ace_acc_pointer_green","Optic_ERCO_blk_f"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vest[] = {"V_SmershVest_01_F"};
     vestContents[] = {
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"o_nvgoggles_grn_f",1},
+      {"rhsusf_100Rnd_762x51_m61_ap",3},
       {"16rnd_9x21_mag",3},
-      {"handgrenade",2},
       {"ace_maptools",1}
     };
 
     backpack[]={"b_kitbag_sgg"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"muzzle_snds_h_mg_blk_f",1},
-      {"rhsusf_100Rnd_762x51_m80a1epr",3},
+      {"rhsusf_100Rnd_762x51_m61_ap",3},
       {"SmokeShell",2},
       {"handgrenade",2}
     };
@@ -476,15 +551,15 @@
   class LMG: baseUnit {
  
     weapons[] = {
-      {"rhs_weap_m249_light_S_vfg2",
-        {"rhsusf_100Rnd_556x45_mixed_soft_pouch_coyote","rhsusf_acc_anpeq15side_bk","optic_Holosight_blk_F","rhsusf_acc_grip4_bipod"},
+      {"CUP_arifle_Mk16_SV_woodland",
+        {"150Rnd_556x45_Drum_Green_Mag_F","ace_acc_pointer_green","optic_Holosight_khk_F","bipod_02_F_lush"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
           {"16rnd_9x21_mag"}
       }
     };
     vestContents[] = {
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",2},
+      {"150Rnd_556x45_Drum_Green_Mag_F",2},
       {"SmokeShell",2},
       {"16rnd_9x21_mag",2},
       {"handgrenade",2},
@@ -492,8 +567,9 @@
     };
 
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",4},
+      {"150Rnd_556x45_Drum_Green_Mag_F",6},
       {"SmokeShell",2},
       {"handgrenade",2}
     };   
@@ -502,23 +578,24 @@
   class GPMGA: baseUnit {
 
     weapons[] = {
-      {"rhs_weap_m16a4_imod_grip",
-        {"rhs_mag_30Rnd_556x45_Mk262_PMAG","ace_acc_pointer_green","optic_Holosight_blk_F"},
+      {"CUP_arifle_Mk16_SV_woodland",
+        {"CUP_30Rnd_556x45_Emag","ace_acc_pointer_green","optic_Holosight_khk_F","bipod_02_F_lush"},
       },
-      {"hgun_p07_khk_f",
+      {"CUP_hgun_Duty",
         {"16rnd_9x21_mag"}
       },
       "binocular"
     };
 
-    backpack[]={"b_carryall_oli"};
+    backpack[]={"b_carryall_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"rhsusf_acc_rotex5_grey",1},
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",4},
+      {"CUP_30Rnd_556x45_Emag",4},
       {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",2},
       {"SmokeShell",2},
       {"handgrenade",2},
-      {"rhsusf_100Rnd_762x51_m80a1epr",4},	  
+      {"rhsusf_100Rnd_762x51_m61_ap",4},	  
       {"rhsusf_100Rnd_762x51_m62_tracer",2}
     };
   };
@@ -526,11 +603,11 @@
   class PT: baseUnit {
 
     weapons[] = {
-      {"smg_03c_tr_black",
-        {"50rnd_570x28_smg_03","ace_acc_pointer_green","optic_Holosight_smg_blk_F"},
+      {"cup_smg_mac10_rail",
+        {"CUP_30Rnd_45ACP_MAC10_M","ace_acc_pointer_green","optic_Holosight_smg_blk_F","rhs_acc_grip_rk2"}
       },
-      {"hgun_p07_khk_f",
-          {"16rnd_9x21_mag"}
+      {"CUP_hgun_Duty",
+        {"16rnd_9x21_mag"}
       }
     };
 
@@ -545,15 +622,16 @@
     vest[] = {"v_tacChestrig_oli_f"};
     vestContents[] = {
       {"acre_prc148",1},
-      {"50rnd_570x28_smg_03",2},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},
       {"ace_maptools",1}
     };
 
-    backpack[] = {"b_tacticalpack_oli"};
+    backpack[] = {"b_fieldpack_green_f"};
     backpackContents[] = {
+      {"o_nvgoggles_grn_f",1},
       {"SmokeShell",2},
-      {"50rnd_570x28_smg_03",4},
+      {"CUP_30Rnd_45ACP_MAC10_M",3},
       {"16rnd_9x21_mag",2},	  
       {"SmokeShellgreen",2},
       {"handgrenade",2},
@@ -563,7 +641,9 @@
       {"ace_microdagr",1}
     };
   };
+
   class PILOT: PT {};
+
   class LauncherCrate {
     vehCargoWeapons[] = {
       {"rhs_weap_m72a7",10},
@@ -576,7 +656,7 @@
       {"MRAWS_HEAT_F",10}
     };
     vehCargoRucks[] = {
-      {"b_fieldpack_green_f",2}
+      {"b_carryall_green_f",2}
     };
   };
   class LargeGearCrate {
@@ -585,15 +665,15 @@
       {"ACE_Vector",2}
     };
     vehCargoMagazines[] = {
-      {"rhs_mag_30Rnd_556x45_Mk262_PMAG",40},
+      {"CUP_30Rnd_556x45_Emag",40},
       {"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",10},
-      {"rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote",10},
-      {"rhsusf_20Rnd_762x51_sr25_Mk316_special_Mag",10},
-      {"rhsusf_20Rnd_762x51_SR25_m62_Mag",4},
-      {"rhsusf_100Rnd_762x51_m80a1epr",8},
+      {"150Rnd_556x45_Drum_Green_Mag_F",10},
+      {"rhs_mag_20Rnd_SCAR_762x51_m80a1_epr",10},
+      {"rhs_mag_20Rnd_SCAR_762x51_m62_tracer",4},
+      {"rhsusf_100Rnd_762x51_m61_ap",8},
       {"handgrenade",20},
       {"SmokeShell",10},
-      {"rhs_mag_m433_hedp",20},
+      {"cup_1rnd_hedp_m203",20},
       {"ClaymoreDirectionalMine_Remote_Mag",4},
       {"SLAMDirectionalMine_Wire_Mag",6},
       {"DemoCharge_Remote_Mag",8}
@@ -616,7 +696,7 @@
       {"ACE_MapTools",4}
     };
     vehCargoRucks[] = {
-      {"b_carryall_oli",4}
+      {"b_carryall_green_f",4}
     };
   };
 };

--- a/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/loadouts.hpp
+++ b/CO18_CZ_Tanoa_V29.Tanoa/tb3/murk/loadouts.hpp
@@ -1,3 +1,6 @@
 #include "cdf_blk.hpp"
 #include "cdf_des.hpp"
 #include "cdf_wdl.hpp"
+#include "cdf_rus.hpp"
+#include "cdf_liz.hpp"
+#include "cdf_jng.hpp"


### PR DESCRIPTION
CDF Loadout Update

- Errant NVGs added to wdl, des, blk classes that accidentally had them removed
- CDF_jng, CDF_rus and CDF_liz added. Tropic being NATO LRRP stuff, the other pair being com-bloc equipped crabs
- CRAB radio bags added for all RTOs
- Some weapons changed due to inclusion of CUP (M240s moving to M60s and Mk48s etc)
- Minor changes to optics for DMRs and SL
- Weights kept <37kg, substantially so in some cases
- Superfluous or wrongly added items have been cleaned up